### PR TITLE
Misc. 2D Texture upload fixes.

### DIFF
--- a/crates/renderide/src/assets/texture/layout.rs
+++ b/crates/renderide/src/assets/texture/layout.rs
@@ -106,6 +106,25 @@ pub fn mip_byte_len(format: TextureFormat, width: u32, height: u32) -> Option<u6
     }
 }
 
+/// Converts `mip_starts[i]` (after subtracting any descriptor rebasing bias) from host **linear texel**
+/// addressing into a **byte offset** into the tight-packed mip payload.
+///
+/// Shared-memory uploads may still report offsets in texel units; this maps them using the size of a
+/// minimal tile (`1×1` texels in host packing, or one compressed block) relative to [`block_extent`].
+pub fn host_mip_payload_byte_offset(
+    format: TextureFormat,
+    start_texel_linear: usize,
+) -> Option<usize> {
+    let (bw, bh) = block_extent(format);
+    let texels_per_tile = (bw as usize).checked_mul(bh as usize)?;
+    if texels_per_tile == 0 {
+        return None;
+    }
+    let tile_bytes = mip_byte_len(format, 1, 1)? as usize;
+    let numer = start_texel_linear.checked_mul(tile_bytes)?;
+    Some(numer.div_ceil(texels_per_tile))
+}
+
 /// Returns the width and height of mip `level` in a standard mip chain (matches wgpu/WebGPU mip sizing).
 ///
 /// `level` 0 is the base size; each subsequent level halves each dimension, clamped to at least 1.

--- a/crates/renderide/src/assets/texture/upload/mip_write_common.rs
+++ b/crates/renderide/src/assets/texture/upload/mip_write_common.rs
@@ -2,7 +2,7 @@
 
 use crate::shared::SetTexture2DData;
 
-use super::super::layout::mip_byte_len;
+use super::super::layout::{host_mip_payload_byte_offset, mip_byte_len};
 
 /// Picks the descriptor offset bias that maximizes how many mips fit in the SHM payload.
 pub(super) fn choose_mip_start_bias(
@@ -58,7 +58,16 @@ pub(super) fn valid_mip_prefix_len(
         if start_abs < bias {
             break;
         }
-        let start = start_abs - bias;
+        let start_rel = start_abs - bias;
+        let start = match host_mip_payload_byte_offset(format, start_rel) {
+            Some(b) => b,
+            None => {
+                return Err(format!(
+                    "mip {i}: could not convert mip_starts offset to bytes for {:?}",
+                    format
+                ));
+            }
+        };
         if start
             .checked_add(host_len)
             .is_none_or(|end| end > payload_len)

--- a/crates/renderide/src/assets/texture/upload/write_mip_chain.rs
+++ b/crates/renderide/src/assets/texture/upload/write_mip_chain.rs
@@ -157,12 +157,12 @@ impl TextureMipChainUploader {
 
         let (gw, gh) = mip_dimensions_at_level(tex_extent.width, tex_extent.height, mip_level);
         if w != gw || h != gh {
-            return Err(format!(
-                "texture {} mip {mip_level}: upload says {w}x{h} but GPU mip is {gw}x{gh} (base {}x{} from format); fix host SetTexture2DFormat vs SetTexture2DData",
+            logger::trace!(
+                "texture {} mip {mip_level}: upload says {w}x{h} but GPU mip is {gw}x{gh} (base {}x{} from format)",
                 upload.asset_id,
                 tex_extent.width,
                 tex_extent.height
-            ));
+            );
         }
 
         let start_raw = upload.mip_starts[i];
@@ -236,18 +236,18 @@ impl TextureMipChainUploader {
             if needs_rgba8_decode_before_upload(fmt.format) || host_format_is_compressed(fmt.format)
             {
                 std::borrow::Cow::Owned(
-                    decode_mip_to_rgba8(fmt.format, w, h, flip, mip_src).ok_or_else(|| {
+                    decode_mip_to_rgba8(fmt.format, gw, gh, flip, mip_src).ok_or_else(|| {
                         format!("RGBA decode failed for mip {i} ({:?})", fmt.format)
                     })?,
                 )
             } else if flip {
                 let mut v = mip_src.to_vec();
-                let bpp = mip_tight_bytes_per_texel(v.len(), w, h).ok_or_else(|| {
+                let bpp = mip_tight_bytes_per_texel(v.len(), gw, gh).ok_or_else(|| {
                     format!(
                         "mip {i}: RGBA8 upload len {} not divisible by {}×{} texels",
                         v.len(),
-                        w,
-                        h
+                        gw,
+                        gh
                     )
                 })?;
                 if bpp != 4 {
@@ -255,7 +255,7 @@ impl TextureMipChainUploader {
                         "mip {i}: RGBA8 family expects 4 bytes per texel, got {bpp}"
                     ));
                 }
-                flip_mip_rows(&mut v, w, h, bpp);
+                flip_mip_rows(&mut v, gw, gh, bpp);
                 std::borrow::Cow::Owned(v)
             } else {
                 std::borrow::Cow::Borrowed(mip_src)
@@ -269,12 +269,12 @@ impl TextureMipChainUploader {
             }
             if flip && !host_format_is_compressed(fmt.format) {
                 let mut v = mip_src.to_vec();
-                let bpp_host = mip_tight_bytes_per_texel(v.len(), w, h).ok_or_else(|| {
+                let bpp_host = mip_tight_bytes_per_texel(v.len(), gw, gh).ok_or_else(|| {
                     format!(
                         "mip {i}: len {} not divisible by {}×{} texels (cannot infer row stride for flip_y)",
                         v.len(),
-                        w,
-                        h
+                        gw,
+                        gh
                     )
                 })?;
                 if let Ok(bpp_gpu) = uncompressed_row_bytes(wgpu_format) {
@@ -306,8 +306,8 @@ impl TextureMipChainUploader {
             queue,
             texture,
             mip_level,
-            w,
-            h,
+            gw,
+            gh,
             wgpu_format,
             pixels.as_ref(),
         )?;

--- a/crates/renderide/src/assets/texture/upload/write_mip_chain.rs
+++ b/crates/renderide/src/assets/texture/upload/write_mip_chain.rs
@@ -1,5 +1,6 @@
 //! Full mip chain path: decode, optional flip, [`super::mip_write_common::write_one_mip`] per level.
 
+use crate::assets::texture::layout::block_extent;
 use crate::shared::{SetTexture2DData, SetTexture2DFormat};
 
 use super::super::decode::{decode_mip_to_rgba8, flip_mip_rows, needs_rgba8_decode_before_upload};
@@ -205,6 +206,9 @@ impl TextureMipChainUploader {
             });
         }
         let start = start_abs - start_bias;
+        let block_dims = block_extent(fmt.format);
+        let start = (start * mip_byte_len(fmt.format, 1, 1).unwrap() as usize)
+            .div_ceil(block_dims.0 as usize * block_dims.1 as usize);
         let host_len = mip_byte_len(fmt.format, w, h)
             .ok_or_else(|| format!("mip byte size unsupported for {:?}", fmt.format))?
             as usize;

--- a/crates/renderide/src/assets/texture/upload/write_mip_chain.rs
+++ b/crates/renderide/src/assets/texture/upload/write_mip_chain.rs
@@ -1,6 +1,6 @@
 //! Full mip chain path: decode, optional flip, [`super::mip_write_common::write_one_mip`] per level.
 
-use crate::assets::texture::layout::block_extent;
+use crate::assets::texture::layout::host_mip_payload_byte_offset;
 use crate::shared::{SetTexture2DData, SetTexture2DFormat};
 
 use super::super::decode::{decode_mip_to_rgba8, flip_mip_rows, needs_rgba8_decode_before_upload};
@@ -158,8 +158,8 @@ impl TextureMipChainUploader {
 
         let (gw, gh) = mip_dimensions_at_level(tex_extent.width, tex_extent.height, mip_level);
         if w != gw || h != gh {
-            logger::trace!(
-                "texture {} mip {mip_level}: upload says {w}x{h} but GPU mip is {gw}x{gh} (base {}x{} from format)",
+            logger::debug!(
+                "texture {} mip {mip_level}: mip_map_sizes {w}x{h} != GPU {gw}x{gh} (using GPU dimensions; base {}x{})",
                 upload.asset_id,
                 tex_extent.width,
                 tex_extent.height
@@ -205,10 +205,13 @@ impl TextureMipChainUploader {
                 total_uploaded: self.uploaded_mips,
             });
         }
-        let start = start_abs - start_bias;
-        let block_dims = block_extent(fmt.format);
-        let start = (start * mip_byte_len(fmt.format, 1, 1).unwrap() as usize)
-            .div_ceil(block_dims.0 as usize * block_dims.1 as usize);
+        let start_rel = start_abs - start_bias;
+        let start = host_mip_payload_byte_offset(fmt.format, start_rel).ok_or_else(|| {
+            format!(
+                "texture {} mip {mip_level}: mip start offset unsupported for {:?}",
+                upload.asset_id, fmt.format
+            )
+        })?;
         let host_len = mip_byte_len(fmt.format, w, h)
             .ok_or_else(|| format!("mip byte size unsupported for {:?}", fmt.format))?
             as usize;
@@ -292,7 +295,7 @@ impl TextureMipChainUploader {
                         );
                     }
                 }
-                flip_mip_rows(&mut v, w, h, bpp_host);
+                flip_mip_rows(&mut v, gw, gh, bpp_host);
                 std::borrow::Cow::Owned(v)
             } else {
                 if flip && host_format_is_compressed(fmt.format) {

--- a/crates/renderide/src/gpu/instance_limits.rs
+++ b/crates/renderide/src/gpu/instance_limits.rs
@@ -11,15 +11,15 @@
 /// [`wgpu::Limits::max_storage_buffer_binding_size`] are set from the adapter so large mesh uploads
 /// (blendshape packs, etc.) can use the full reported allowance—WebGPU defaults alone cap
 /// [`wgpu::Limits::max_buffer_size`] at 256 MiB while the adapter often allows more.
-/// [`wgpu::Limits::max_texture_dimension_2d`] is increased to 16k if available, to match resonite's
-/// current maximum texture size.
+/// [`wgpu::Limits::max_texture_dimension_2d`] is capped at **16384** when the adapter allows it,
+/// matching the host’s maximum 2D texture size.
 pub(crate) fn required_limits_for_adapter(adapter: &wgpu::Adapter) -> wgpu::Limits {
     let al = adapter.limits();
     let mut limits = wgpu::Limits::default().or_worse_values_from(&al);
     limits.max_buffer_size = al.max_buffer_size;
     limits.max_storage_buffer_binding_size = al.max_storage_buffer_binding_size;
 
-    limits.max_texture_dimension_2d = std::cmp::min(al.max_texture_dimension_2d, 16386);
+    limits.max_texture_dimension_2d = std::cmp::min(al.max_texture_dimension_2d, 16384);
     limits
 }
 

--- a/crates/renderide/src/gpu/instance_limits.rs
+++ b/crates/renderide/src/gpu/instance_limits.rs
@@ -11,11 +11,15 @@
 /// [`wgpu::Limits::max_storage_buffer_binding_size`] are set from the adapter so large mesh uploads
 /// (blendshape packs, etc.) can use the full reported allowance—WebGPU defaults alone cap
 /// [`wgpu::Limits::max_buffer_size`] at 256 MiB while the adapter often allows more.
+/// [`wgpu::Limits::max_texture_dimension_2d`] is increased to 16k if available, to match resonite's
+/// current maximum texture size.
 pub(crate) fn required_limits_for_adapter(adapter: &wgpu::Adapter) -> wgpu::Limits {
     let al = adapter.limits();
     let mut limits = wgpu::Limits::default().or_worse_values_from(&al);
     limits.max_buffer_size = al.max_buffer_size;
     limits.max_storage_buffer_binding_size = al.max_storage_buffer_binding_size;
+
+    limits.max_texture_dimension_2d = std::cmp::min(al.max_texture_dimension_2d, 16386);
     limits
 }
 


### PR DESCRIPTION
You may wish to rewrite the contents of the latter two commits for various reasons, since I find certain aspects of this codebase confusing. Such as, "what exactly is start_bias in this context and why is it here?"

The last commit, in particular, should probably involve its own helper function.

Similar fixes may be needed for other types of textures.

I'm hoping that, now that mipmaps are (somewhat?) consistently present, this will provide a better base for working on getting text working.