### PR TITLE
Fix Unlit/UI_Unlit additive mode with mask

### DIFF
--- a/crates/renderide/shaders/source/materials/ui_unlit.wgsl
+++ b/crates/renderide/shaders/source/materials/ui_unlit.wgsl
@@ -31,7 +31,6 @@ struct UiUnlitMaterial {
     _MaskTex_ST: vec4<f32>,
     _Tint: vec4<f32>,
     _Cutoff: f32,
-    _MUL_RGB_BY_ALPHA_ON: f32,
     _ALPHATEST_ON: f32,
     _ALPHABLEND_ON: f32,
     _MainTex_LodBias: f32,
@@ -89,22 +88,19 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
 
     let alpha_test = uvu::kw_enabled(mat._ALPHATEST_ON);
     let alpha_blend = uvu::kw_enabled(mat._ALPHABLEND_ON);
-    let mul_rgb_by_alpha = uvu::kw_enabled(mat._MUL_RGB_BY_ALPHA_ON);
 
     let uv_mask = uvu::apply_st(in.uv, mat._MaskTex_ST);
-    let mask_sample = ts::sample_tex_2d(_MaskTex, _MaskTex_sampler, uv_s, mat._MaskTex_LodBias);
-    let mask = mask_sample.a * (mask_sample.r + mask_sample.g + mask_sample.b) * 0.33333334;
 
     if (alpha_test) {
-        if (color.a * mask <= mat._Cutoff){
+        let tex_clip_alpha = in.color.a * acs::texture_alpha_base_mip(_MainTex, _MainTex_sampler, uv_s);
+        let mask_clip_alpha = acs::mask_luminance_mul_base_mip(_MaskTex, _MaskTex_sampler, uv_mask);
+        if (tex_clip_alpha * mask_clip_alpha <= mat._Cutoff) {
             discard;
         }
-    } else {
+    } else if (alpha_blend) {
+        let mask_sample = ts::sample_tex_2d(_MaskTex, _MaskTex_sampler, uv_mask, mat._MaskTex_LodBias);
+        let mask = mask_sample.a * (mask_sample.r + mask_sample.g + mask_sample.b) * 0.33333334;
         color.a = color.a * mask;
-    }
-
-    if (mul_rgb_by_alpha) {
-        color = vec4<f32>(color.x*color.a, color.y*color.a, color.z*color.a, color.a);
     }
 
     return rg::retain_globals_additive(color);

--- a/crates/renderide/shaders/source/materials/ui_unlit.wgsl
+++ b/crates/renderide/shaders/source/materials/ui_unlit.wgsl
@@ -19,6 +19,7 @@
 //! Per-draw uniforms (`@group(2)`) use [`renderide::per_draw`].
 
 
+#import renderide::texture_sampling as ts
 #import renderide::globals as rg
 #import renderide::per_draw as pd
 #import renderide::alpha_clip_sample as acs
@@ -30,8 +31,11 @@ struct UiUnlitMaterial {
     _MaskTex_ST: vec4<f32>,
     _Tint: vec4<f32>,
     _Cutoff: f32,
+    _MUL_RGB_BY_ALPHA_ON: f32,
     _ALPHATEST_ON: f32,
     _ALPHABLEND_ON: f32,
+    _MainTex_LodBias: f32,
+    _MaskTex_LodBias: f32,
 }
 
 @group(1) @binding(0) var<uniform> mat: UiUnlitMaterial;
@@ -80,21 +84,27 @@ fn vs_main(
 @fragment
 fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     let uv_s = uvu::apply_st_for_storage(in.uv, mat._MainTex_ST, mat._MainTex_StorageVInverted);
-    let t = textureSample(_MainTex, _MainTex_sampler, uv_s);
+    let t = ts::sample_tex_2d(_MainTex, _MainTex_sampler, uv_s, mat._MainTex_LodBias);
     var color = in.color * t;
-    var clip_a = in.color.a * acs::texture_alpha_base_mip(_MainTex, _MainTex_sampler, uv_s);
 
-    let uv_mask = uvu::apply_st(in.uv, mat._MaskTex_ST);
     let alpha_test = uvu::kw_enabled(mat._ALPHATEST_ON);
     let alpha_blend = uvu::kw_enabled(mat._ALPHABLEND_ON);
+    let mul_rgb_by_alpha = uvu::kw_enabled(mat._MUL_RGB_BY_ALPHA_ON);
+
+    let uv_mask = uvu::apply_st(in.uv, mat._MaskTex_ST);
+    let mask_sample = ts::sample_tex_2d(_MaskTex, _MaskTex_sampler, uv_s, mat._MaskTex_LodBias);
+    let mask = mask_sample.a * (mask_sample.r + mask_sample.g + mask_sample.b) * 0.33333334;
+
     if (alpha_test) {
-        clip_a = clip_a * acs::texture_alpha_base_mip(_MaskTex, _MaskTex_sampler, uv_mask);
-    } else if (alpha_blend) {
-        color.a = color.a * textureSample(_MaskTex, _MaskTex_sampler, uv_mask).a;
+        if (color.a * mask <= mat._Cutoff){
+            discard;
+        }
+    } else {
+        color.a = color.a * mask;
     }
 
-    if (alpha_test && clip_a <= mat._Cutoff) {
-        discard;
+    if (mul_rgb_by_alpha) {
+        color = vec4<f32>(color.x*color.a, color.y*color.a, color.z*color.a, color.a);
     }
 
     return rg::retain_globals_additive(color);

--- a/crates/renderide/shaders/source/materials/unlit.wgsl
+++ b/crates/renderide/shaders/source/materials/unlit.wgsl
@@ -18,6 +18,7 @@
 //! cutoff branches stay inert. The default-white texture fallback keeps each mask branch a
 //! no-op when no host mask is bound (`mask.a == 1.0`).
 
+#import renderide::texture_sampling as ts
 #import renderide::globals as rg
 #import renderide::per_draw as pd
 #import renderide::alpha_clip_sample as acs
@@ -32,8 +33,12 @@ struct UnlitMaterial {
     _OffsetMagnitude: vec4<f32>,
     _Cutoff: f32,
     _PolarPow: f32,
+    _MUL_RGB_BY_ALPHA_ON: f32,
     _ALPHATEST_ON: f32,
     _ALPHABLEND_ON: f32,
+    _Tex_LodBias: f32,
+    _OffsetTex_LodBias: f32,
+    _MaskTex_LodBias: f32,
 }
 
 @group(1) @binding(0) var<uniform> mat: UnlitMaterial;
@@ -81,25 +86,31 @@ fn vs_main(
 @fragment
 fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     let uv_off = uvu::apply_st(in.uv, mat._OffsetTex_ST);
-    let offset_s = textureSample(_OffsetTex, _OffsetTex_sampler, uv_off);
+    let offset_s = ts::sample_tex_2d(_OffsetTex, _OffsetTex_sampler, uv_off, mat._OffsetTex_LodBias);
     let uv_main = uvu::apply_st_for_storage(in.uv, mat._Tex_ST, mat._Tex_StorageVInverted) + offset_s.xy * mat._OffsetMagnitude.xy;
 
-    let t = textureSample(_Tex, _Tex_sampler, uv_main);
-    var albedo = mat._Color * t;
-    var clip_a = mat._Color.a * acs::texture_alpha_base_mip(_Tex, _Tex_sampler, uv_main);
+    let t = ts::sample_tex_2d(_Tex, _Tex_sampler, uv_main, mat._Tex_LodBias);
+    var color = mat._Color * t;
 
-    let uv_mask = uvu::apply_st(in.uv, mat._MaskTex_ST);
     let alpha_test = uvu::kw_enabled(mat._ALPHATEST_ON);
     let alpha_blend = uvu::kw_enabled(mat._ALPHABLEND_ON);
+    let mul_rgb_by_alpha = uvu::kw_enabled(mat._MUL_RGB_BY_ALPHA_ON);
+
+    let uv_mask = uvu::apply_st(in.uv, mat._MaskTex_ST);
+    let mask_sample = ts::sample_tex_2d(_MaskTex, _MaskTex_sampler, uv_mask, mat._MaskTex_LodBias);
+    let mask = mask_sample.a * (mask_sample.r + mask_sample.g + mask_sample.b) * 0.33333334;
+
     if (alpha_test) {
-        clip_a = clip_a * acs::texture_alpha_base_mip(_MaskTex, _MaskTex_sampler, uv_mask);
-    } else if (alpha_blend) {
-        albedo.a = albedo.a * textureSample(_MaskTex, _MaskTex_sampler, uv_mask).a;
+        if (color.a * mask <= mat._Cutoff){
+            discard;
+        }
+    } else {
+        color.a = color.a * mask;
     }
 
-    if (alpha_test && clip_a <= mat._Cutoff) {
-        discard;
+    if (mul_rgb_by_alpha) {
+        color = vec4<f32>(color.x*color.a, color.y*color.a, color.z*color.a, color.a);
     }
 
-    return rg::retain_globals_additive(albedo);
+    return rg::retain_globals_additive(color);
 }

--- a/crates/renderide/shaders/source/materials/unlit.wgsl
+++ b/crates/renderide/shaders/source/materials/unlit.wgsl
@@ -11,7 +11,7 @@
 //! Mask-mode caveat: Unity's Unlit shader gates mask application on
 //! `_MASK_TEXTURE_MUL` / `_MASK_TEXTURE_CLIP` multi-compile keywords that FrooxEngine sets
 //! through `ShaderKeywords.SetKeyword`, which the renderer never receives. The
-//! `_ALPHATEST_ON` and `_ALPHABLEND_ON` keyword fields below are populated by
+//! `_ALPHATEST_ON`, `_ALPHABLEND_ON`, and `_MUL_RGB_BY_ALPHA` keyword fields below are populated by
 //! [`crate::backend::embedded::uniform_pack::inferred_keyword_float_f32`] from the on-wire
 //! `MaterialRenderType` tag (Cutout enables `_ALPHATEST_ON`; Transparent enables
 //! `_ALPHABLEND_ON`). When neither is set the material is treated as Opaque and the mask /
@@ -33,7 +33,7 @@ struct UnlitMaterial {
     _OffsetMagnitude: vec4<f32>,
     _Cutoff: f32,
     _PolarPow: f32,
-    _MUL_RGB_BY_ALPHA_ON: f32,
+    _MUL_RGB_BY_ALPHA: f32,
     _ALPHATEST_ON: f32,
     _ALPHABLEND_ON: f32,
     _Tex_LodBias: f32,
@@ -94,22 +94,24 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
 
     let alpha_test = uvu::kw_enabled(mat._ALPHATEST_ON);
     let alpha_blend = uvu::kw_enabled(mat._ALPHABLEND_ON);
-    let mul_rgb_by_alpha = uvu::kw_enabled(mat._MUL_RGB_BY_ALPHA_ON);
+    let mul_rgb_by_alpha = uvu::kw_enabled(mat._MUL_RGB_BY_ALPHA);
 
     let uv_mask = uvu::apply_st(in.uv, mat._MaskTex_ST);
-    let mask_sample = ts::sample_tex_2d(_MaskTex, _MaskTex_sampler, uv_mask, mat._MaskTex_LodBias);
-    let mask = mask_sample.a * (mask_sample.r + mask_sample.g + mask_sample.b) * 0.33333334;
 
     if (alpha_test) {
-        if (color.a * mask <= mat._Cutoff){
+        let tex_clip_alpha = mat._Color.a * acs::texture_alpha_base_mip(_Tex, _Tex_sampler, uv_main);
+        let mask_clip_alpha = acs::mask_luminance_mul_base_mip(_MaskTex, _MaskTex_sampler, uv_mask);
+        if (tex_clip_alpha * mask_clip_alpha <= mat._Cutoff) {
             discard;
         }
-    } else {
+    } else if (alpha_blend) {
+        let mask_sample = ts::sample_tex_2d(_MaskTex, _MaskTex_sampler, uv_mask, mat._MaskTex_LodBias);
+        let mask = mask_sample.a * (mask_sample.r + mask_sample.g + mask_sample.b) * 0.33333334;
         color.a = color.a * mask;
     }
 
     if (mul_rgb_by_alpha) {
-        color = vec4<f32>(color.x*color.a, color.y*color.a, color.z*color.a, color.a);
+        color = vec4<f32>(color.rgb * color.a, color.a);
     }
 
     return rg::retain_globals_additive(color);

--- a/crates/renderide/src/backend/embedded/layout.rs
+++ b/crates/renderide/src/backend/embedded/layout.rs
@@ -19,7 +19,7 @@ pub(crate) struct StemMaterialLayout {
 
 /// Pre-interned property ids used by [`super::uniform_pack::inferred_keyword_float_f32`] to
 /// probe texture presence (PBS `_NORMALMAP` / `_EMISSION` / `_SPECULARMAP` / … flags) and by
-/// the `_ALPHATEST_ON`/`_ALPHABLEND_ON` inference path that reads three on-wire signals,
+/// the `_ALPHATEST_ON` / `_ALPHABLEND_ON` / `_MUL_RGB_BY_ALPHA` inference path that reads on-wire signals,
 /// each captured as a synthetic property by
 /// [`crate::assets::material::parse_materials_update_batch_into_store`]:
 ///
@@ -28,7 +28,7 @@ pub(crate) struct StemMaterialLayout {
 /// 2. The Unity render queue at `_RenderQueue` (PBS `AlphaHandling` family —
 ///    `PBS_DualSidedMaterial.cs` and friends bypass `SetBlendMode` and the `_ALPHACLIP`
 ///    keyword bitmask, signaling AlphaClip via queue 2450 and Opaque via queue 2000).
-/// 3. The `_SrcBlend` / `_DstBlend` factors for distinguishing alpha-blend from
+/// 3. The `_SrcBlend` / `_DstBlend` factors for distinguishing alpha-blend, additive, and
 ///    premultiplied alpha within the Transparent range.
 ///
 /// FrooxEngine's `ShaderKeywords.Variant` bitmask is never sent over IPC, so every

--- a/crates/renderide/src/backend/embedded/uniform_pack/tables.rs
+++ b/crates/renderide/src/backend/embedded/uniform_pack/tables.rs
@@ -8,6 +8,7 @@ use super::helpers::{
     shader_writer_unescaped_field_name, texture_property_present_pids,
 };
 
+/// Infers a scalar keyword uniform from host-visible material state.
 pub(super) fn inferred_keyword_float_f32(
     field_name: &str,
     store: &MaterialPropertyStore,
@@ -44,8 +45,8 @@ pub(super) fn inferred_keyword_float_f32(
                 0.0
             });
         }
-        "_MUL_RGB_BY_ALPHA_ON" => {
-            return Some(if mul_rgb_by_alpha_on_inferred(store, lookup, kw) {
+        "_MUL_RGB_BY_ALPHA" => {
+            return Some(if mul_rgb_by_alpha_inferred(store, lookup, kw) {
                 1.0
             } else {
                 0.0
@@ -119,6 +120,7 @@ const RENDER_QUEUE_ALPHA_TEST_MIN: i32 = 2450;
 /// exclusive upper bound of the AlphaTest range.
 const RENDER_QUEUE_TRANSPARENT_MIN: i32 = 3000;
 
+/// Reads a float-valued material property as the integer enum/discriminant it represents.
 fn read_int_property(
     store: &MaterialPropertyStore,
     lookup: MaterialPropertyLookupIds,
@@ -127,6 +129,7 @@ fn read_int_property(
     first_float_by_pids(store, lookup, &[kw_pid]).map(|v| v.round() as i32)
 }
 
+/// Returns whether either render-type or older mode properties match the requested values.
 fn render_type_or_legacy_mode_is(
     store: &MaterialPropertyStore,
     lookup: MaterialPropertyLookupIds,
@@ -142,23 +145,47 @@ fn render_type_or_legacy_mode_is(
     legacy_mode == Some(legacy_mode_value) || legacy_blend == Some(legacy_mode_value)
 }
 
+/// Returns whether the host blend factors match `src_factor` and `dst_factor`.
+fn blend_factors_are(
+    store: &MaterialPropertyStore,
+    lookup: MaterialPropertyLookupIds,
+    kw: &EmbeddedSharedKeywordIds,
+    src_factor: i32,
+    dst_factor: i32,
+) -> bool {
+    let src = read_int_property(store, lookup, kw.src_blend);
+    let dst = read_int_property(store, lookup, kw.dst_blend);
+    src == Some(src_factor) && dst == Some(dst_factor)
+}
+
+/// Returns whether blend factors describe Unity/FrooxEngine premultiplied alpha blending.
 fn premultiplied_blend_factors(
     store: &MaterialPropertyStore,
     lookup: MaterialPropertyLookupIds,
     kw: &EmbeddedSharedKeywordIds,
 ) -> bool {
-    let src = read_int_property(store, lookup, kw.src_blend);
-    let dst = read_int_property(store, lookup, kw.dst_blend);
-    src == Some(UNITY_BLEND_FACTOR_ONE) && dst == Some(UNITY_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA)
+    blend_factors_are(
+        store,
+        lookup,
+        kw,
+        UNITY_BLEND_FACTOR_ONE,
+        UNITY_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA,
+    )
 }
+
+/// Returns whether blend factors describe Unity/FrooxEngine additive blending.
 fn additive_blend_factors(
     store: &MaterialPropertyStore,
     lookup: MaterialPropertyLookupIds,
     kw: &EmbeddedSharedKeywordIds,
 ) -> bool {
-    let src = read_int_property(store, lookup, kw.src_blend);
-    let dst = read_int_property(store, lookup, kw.dst_blend);
-    src == Some(UNITY_BLEND_FACTOR_ONE) && dst == Some(UNITY_BLEND_FACTOR_ONE)
+    blend_factors_are(
+        store,
+        lookup,
+        kw,
+        UNITY_BLEND_FACTOR_ONE,
+        UNITY_BLEND_FACTOR_ONE,
+    )
 }
 
 /// Classification of an inferred render queue value.
@@ -176,6 +203,7 @@ enum InferredQueueRange {
     Transparent,
 }
 
+/// Classifies the host render queue into the alpha range implied by Unity's queue constants.
 fn render_queue_range(
     store: &MaterialPropertyStore,
     lookup: MaterialPropertyLookupIds,
@@ -191,6 +219,7 @@ fn render_queue_range(
     }
 }
 
+/// Returns whether host-visible state implies an alpha-test/cutout shader keyword.
 fn alpha_test_on_inferred(
     store: &MaterialPropertyStore,
     lookup: MaterialPropertyLookupIds,
@@ -208,6 +237,7 @@ fn alpha_test_on_inferred(
     )
 }
 
+/// Returns whether host-visible state implies straight alpha blending.
 fn alpha_blend_on_inferred(
     store: &MaterialPropertyStore,
     lookup: MaterialPropertyLookupIds,
@@ -225,6 +255,7 @@ fn alpha_blend_on_inferred(
     legacy_mode == Some(BLEND_MODE_ALPHA) || legacy_blend == Some(BLEND_MODE_ALPHA)
 }
 
+/// Returns whether host-visible state implies premultiplied alpha blending.
 fn alpha_premultiply_on_inferred(
     store: &MaterialPropertyStore,
     lookup: MaterialPropertyLookupIds,
@@ -247,7 +278,8 @@ fn alpha_premultiply_on_inferred(
         || legacy_blend == Some(BLEND_MODE_TRANSPARENT_PREMULTIPLY)
 }
 
-fn mul_rgb_by_alpha_on_inferred(
+/// Returns whether host-visible state implies Unlit's additive RGB-by-alpha multiplication.
+fn mul_rgb_by_alpha_inferred(
     store: &MaterialPropertyStore,
     lookup: MaterialPropertyLookupIds,
     kw: &EmbeddedSharedKeywordIds,

--- a/crates/renderide/src/backend/embedded/uniform_pack/tables.rs
+++ b/crates/renderide/src/backend/embedded/uniform_pack/tables.rs
@@ -253,9 +253,7 @@ fn mul_rgb_by_alpha_on_inferred(
     kw: &EmbeddedSharedKeywordIds,
 ) -> bool {
     let render_type = read_int_property(store, lookup, kw.render_type);
-    if render_type == Some(RENDER_TYPE_TRANSPARENT)
-        && additive_blend_factors(store, lookup, kw)
-    {
+    if render_type == Some(RENDER_TYPE_TRANSPARENT) && additive_blend_factors(store, lookup, kw) {
         return true;
     }
     if render_queue_range(store, lookup, kw) == Some(InferredQueueRange::Transparent)

--- a/crates/renderide/src/backend/embedded/uniform_pack/tables.rs
+++ b/crates/renderide/src/backend/embedded/uniform_pack/tables.rs
@@ -44,6 +44,13 @@ pub(super) fn inferred_keyword_float_f32(
                 0.0
             });
         }
+        "_MUL_RGB_BY_ALPHA_ON" => {
+            return Some(if mul_rgb_by_alpha_on_inferred(store, lookup, kw) {
+                1.0
+            } else {
+                0.0
+            });
+        }
         _ => {}
     }
 
@@ -144,6 +151,15 @@ fn premultiplied_blend_factors(
     let dst = read_int_property(store, lookup, kw.dst_blend);
     src == Some(UNITY_BLEND_FACTOR_ONE) && dst == Some(UNITY_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA)
 }
+fn additive_blend_factors(
+    store: &MaterialPropertyStore,
+    lookup: MaterialPropertyLookupIds,
+    kw: &EmbeddedSharedKeywordIds,
+) -> bool {
+    let src = read_int_property(store, lookup, kw.src_blend);
+    let dst = read_int_property(store, lookup, kw.dst_blend);
+    src == Some(UNITY_BLEND_FACTOR_ONE) && dst == Some(UNITY_BLEND_FACTOR_ONE)
+}
 
 /// Classification of an inferred render queue value.
 ///
@@ -229,6 +245,25 @@ fn alpha_premultiply_on_inferred(
     let legacy_blend = read_int_property(store, lookup, kw.blend_mode);
     legacy_mode == Some(BLEND_MODE_TRANSPARENT_PREMULTIPLY)
         || legacy_blend == Some(BLEND_MODE_TRANSPARENT_PREMULTIPLY)
+}
+
+fn mul_rgb_by_alpha_on_inferred(
+    store: &MaterialPropertyStore,
+    lookup: MaterialPropertyLookupIds,
+    kw: &EmbeddedSharedKeywordIds,
+) -> bool {
+    let render_type = read_int_property(store, lookup, kw.render_type);
+    if render_type == Some(RENDER_TYPE_TRANSPARENT)
+        && additive_blend_factors(store, lookup, kw)
+    {
+        return true;
+    }
+    if render_queue_range(store, lookup, kw) == Some(InferredQueueRange::Transparent)
+        && additive_blend_factors(store, lookup, kw)
+    {
+        return true;
+    }
+    false
 }
 
 // Every uniform field reaching `build_embedded_uniform_bytes` is one of:

--- a/crates/renderide/src/backend/embedded/uniform_pack/tests.rs
+++ b/crates/renderide/src/backend/embedded/uniform_pack/tests.rs
@@ -190,6 +190,70 @@ mod text_uniform_packing_tests {
         );
     }
 
+    /// `BlendMode.Additive` writes Transparent render type with `_SrcBlend = One` and
+    /// `_DstBlend = One`; Unlit uses that signal to enable `_MUL_RGB_BY_ALPHA`.
+    #[test]
+    fn transparent_render_type_with_additive_factors_infers_mul_rgb_by_alpha() {
+        let mut store = MaterialPropertyStore::new();
+        let reg = PropertyIdRegistry::new();
+        let ids = StemEmbeddedPropertyIds::minimal_for_tests(&reg);
+        let render_type_pid = reg.intern("_RenderType");
+        let src_blend_pid = reg.intern("_SrcBlend");
+        let dst_blend_pid = reg.intern("_DstBlend");
+        store.set_material(13, render_type_pid, MaterialPropertyValue::Float(2.0));
+        store.set_material(13, src_blend_pid, MaterialPropertyValue::Float(1.0));
+        store.set_material(13, dst_blend_pid, MaterialPropertyValue::Float(1.0));
+
+        assert_eq!(
+            inferred_keyword_float_f32("_MUL_RGB_BY_ALPHA", &store, lookup(13), &ids),
+            Some(1.0)
+        );
+        assert_eq!(
+            inferred_keyword_float_f32("_ALPHAPREMULTIPLY_ON", &store, lookup(13), &ids),
+            Some(0.0)
+        );
+    }
+
+    /// Additive blend factors alone are not enough; the material must also be in a transparent
+    /// render type or queue range.
+    #[test]
+    fn opaque_render_type_with_additive_factors_does_not_infer_mul_rgb_by_alpha() {
+        let mut store = MaterialPropertyStore::new();
+        let reg = PropertyIdRegistry::new();
+        let ids = StemEmbeddedPropertyIds::minimal_for_tests(&reg);
+        let render_type_pid = reg.intern("_RenderType");
+        let src_blend_pid = reg.intern("_SrcBlend");
+        let dst_blend_pid = reg.intern("_DstBlend");
+        store.set_material(14, render_type_pid, MaterialPropertyValue::Float(0.0));
+        store.set_material(14, src_blend_pid, MaterialPropertyValue::Float(1.0));
+        store.set_material(14, dst_blend_pid, MaterialPropertyValue::Float(1.0));
+
+        assert_eq!(
+            inferred_keyword_float_f32("_MUL_RGB_BY_ALPHA", &store, lookup(14), &ids),
+            Some(0.0)
+        );
+    }
+
+    /// Render queue inference covers materials that signal transparency through queue state rather
+    /// than `MaterialRenderType`.
+    #[test]
+    fn render_queue_transparent_with_additive_factors_infers_mul_rgb_by_alpha() {
+        let mut store = MaterialPropertyStore::new();
+        let reg = PropertyIdRegistry::new();
+        let ids = StemEmbeddedPropertyIds::minimal_for_tests(&reg);
+        let render_queue_pid = reg.intern("_RenderQueue");
+        let src_blend_pid = reg.intern("_SrcBlend");
+        let dst_blend_pid = reg.intern("_DstBlend");
+        store.set_material(15, render_queue_pid, MaterialPropertyValue::Float(3000.0));
+        store.set_material(15, src_blend_pid, MaterialPropertyValue::Float(1.0));
+        store.set_material(15, dst_blend_pid, MaterialPropertyValue::Float(1.0));
+
+        assert_eq!(
+            inferred_keyword_float_f32("_MUL_RGB_BY_ALPHA", &store, lookup(15), &ids),
+            Some(1.0)
+        );
+    }
+
     /// PBS materials (`PBS_DualSidedMaterial.cs` and friends) bypass `SetBlendMode` and
     /// only signal `AlphaHandling.AlphaClip` by writing render queue 2450 plus the
     /// `_ALPHACLIP` shader keyword (which is not on the wire). Queue 2450 alone must


### PR DESCRIPTION
Made it so Unlit and UI_Unlit materials set to additive blending mode have the `_MUL_RGB_BY_ALPHA_ON` exposed, making it so the rgb colors can be multiplied by the alpha.

Some things to note:
- Made it so the shader uses the rgb values from the mask texture too, which was missing before
- I'm not sure if my changes to `crates/renderide/src/backend/embedded/uniform_pack/tables.rs` fully makes sense, I tried following what the rest of the code was doing
- I also made it so these shaders follow the texture's LodBias, I think all materials should