### PR TITLE
xietoon: fix color tints in linear rendering

### DIFF
--- a/crates/renderide/shaders/modules/xiexe_toon2_base.wgsl
+++ b/crates/renderide/shaders/modules/xiexe_toon2_base.wgsl
@@ -429,6 +429,29 @@ fn grayscale(v: vec3<f32>) -> f32 {
     return dot(v, vec3<f32>(0.2125, 0.7154, 0.0721));
 }
 
+/// Converts one sRGB channel to linear for material color properties.
+///
+/// Values above 1.0 are treated as HDR-linear and passed through to avoid
+/// over-amplifying authored HDR tints.
+fn srgb_channel_to_linear(v: f32) -> f32 {
+    if (v > 1.0) {
+        return v;
+    }
+    if (v <= 0.04045) {
+        return v / 12.92;
+    }
+    return pow((v + 0.055) / 1.055, 2.4);
+}
+
+/// Component-wise sRGB->linear conversion for material color uniforms.
+fn srgb_to_linear(v: vec3<f32>) -> vec3<f32> {
+    return vec3<f32>(
+        srgb_channel_to_linear(v.x),
+        srgb_channel_to_linear(v.y),
+        srgb_channel_to_linear(v.z),
+    );
+}
+
 /// Lerps `c` toward its luminance by `(1 - mat._Saturation)`. Matches the Unity behaviour
 /// of `_Saturation = 0` collapsing to greyscale and `_Saturation = 1` keeping full color.
 fn maybe_saturate_color(c: vec3<f32>) -> vec3<f32> {

--- a/crates/renderide/shaders/modules/xiexe_toon2_lighting.wgsl
+++ b/crates/renderide/shaders/modules/xiexe_toon2_lighting.wgsl
@@ -160,7 +160,7 @@ fn rim_light(
 
     var col = rim * xb::mat._RimIntensity * (light.color + ambient);
     col = col * mix(vec3<f32>(1.0), vec3<f32>(light.attenuation) + ambient, clamp(xb::mat._RimAttenEffect, 0.0, 1.0));
-    col = col * xb::mat._RimColor.rgb;
+    col = col * xb::srgb_to_linear(xb::mat._RimColor.rgb);
     col = col * mix(vec3<f32>(1.0), s.diffuse_color, clamp(xb::mat._RimAlbedoTint, 0.0, 1.0));
     col = col * mix(vec3<f32>(1.0), env_map, clamp(xb::mat._RimCubemapTint, 0.0, 1.0));
     return col;
@@ -179,7 +179,7 @@ fn shadow_rim(
     var rim = xb::saturate(1.0 - vdn) * pow(xb::saturate(1.0 - ndl), max(xb::mat._ShadowRimThreshold * 2.0, 0.0));
     rim = smoothstep(xb::mat._ShadowRimRange - sharp, xb::mat._ShadowRimRange + sharp, rim);
 
-    let tint = xb::mat._ShadowRim.rgb * mix(vec3<f32>(1.0), s.diffuse_color, clamp(xb::mat._ShadowRimAlbedoTint, 0.0, 1.0)) + ambient * 0.1;
+    let tint = xb::srgb_to_linear(xb::mat._ShadowRim.rgb) * mix(vec3<f32>(1.0), s.diffuse_color, clamp(xb::mat._ShadowRimAlbedoTint, 0.0, 1.0)) + ambient * 0.1;
     return mix(vec3<f32>(1.0), tint, rim);
 }
 
@@ -190,7 +190,8 @@ fn subsurface(
     view_dir: vec3<f32>,
     ambient: vec3<f32>,
 ) -> vec3<f32> {
-    if (dot(xb::mat._SSColor.rgb, xb::mat._SSColor.rgb) <= 1e-8) {
+    let ss_color = xb::srgb_to_linear(xb::mat._SSColor.rgb);
+    if (dot(ss_color, ss_color) <= 1e-8) {
         return vec3<f32>(0.0);
     }
 
@@ -203,7 +204,7 @@ fn subsurface(
     let attenuation = xb::saturate(light.attenuation * (raw_ndl * 0.5 + 0.5));
     let h = xb::safe_normalize(light.direction + s.normal * xb::mat._SSDistortion, s.normal);
     let vdh = pow(xb::saturate(dot(view_dir, -h)), max(xb::mat._SSPower, 0.001));
-    let scatter = xb::mat._SSColor.rgb * (vdh + ambient) * attenuation * xb::mat._SSScale * s.thickness;
+    let scatter = ss_color * (vdh + ambient) * attenuation * xb::mat._SSScale * s.thickness;
     return max(vec3<f32>(0.0), light.color * scatter * s.albedo.rgb) * ndl * light.attenuation;
 }
 
@@ -253,7 +254,7 @@ fn indirect_reflection_branch(
     if (xb::matcap_enabled()) {
         let uv = matcap_uv(view_dir, normal);
         let lod = clamp((1.0 - clamp(perceptual_roughness, 0.0, 1.0)) * SPECCUBE_LOD_STEPS, 0.0, SPECCUBE_LOD_STEPS);
-        var spec = textureSampleLevel(xb::_Matcap, xb::_Matcap_sampler, uv, lod).rgb * xb::mat._MatcapTint.rgb;
+        var spec = textureSampleLevel(xb::_Matcap, xb::_Matcap_sampler, uv, lod).rgb * xb::srgb_to_linear(xb::mat._MatcapTint.rgb);
         if (!reflection_is_multiplicative()) {
             spec = spec * (ambient + dominant_light_col_atten * 0.5);
         }
@@ -360,7 +361,7 @@ fn emission_color(
     }
 
     var emission = mix(s.emission, s.emission * s.diffuse_color, clamp(xb::mat._EmissionToDiffuse, 0.0, 1.0));
-    emission = emission * xb::mat._EmissionColor.rgb;
+    emission = emission * xb::srgb_to_linear(xb::mat._EmissionColor.rgb);
 
     if (xb::scale_with_light_enabled()) {
         let sensitivity = clamp(xb::mat._ScaleWithLightSensitivity, 0.0, 1.0);

--- a/crates/renderide/shaders/modules/xiexe_toon2_outline.wgsl
+++ b/crates/renderide/shaders/modules/xiexe_toon2_outline.wgsl
@@ -55,7 +55,7 @@ fn vertex_outline(
     let outline_pos = vec4<f32>(pos.xyz + xb::safe_normalize(n.xyz, vec3<f32>(0.0, 1.0, 0.0)) * outline_width, 1.0);
 
     var out = xsurf::vertex_main(instance_index, view_idx, outline_pos, n, uv_primary, color, tangent, uv_secondary);
-    out.color = vec4<f32>(xb::mat._OutlineColor.rgb, 1.0);
+    out.color = vec4<f32>(xb::srgb_to_linear(xb::mat._OutlineColor.rgb), 1.0);
     return out;
 }
 
@@ -79,7 +79,7 @@ fn fragment_outline(
     let s = xsurf::sample_surface(false, front_facing, world_pos, world_n, world_t, world_b, uv_primary, uv_secondary, color);
     let alpha = xa::apply_alpha(alpha_mode, frag_pos.xy, world_pos, view_layer, uv_primary, s.albedo.a, s.clip_alpha);
 
-    var ol = xb::mat._OutlineColor.rgb;
+    var ol = xb::srgb_to_linear(xb::mat._OutlineColor.rgb);
     if (xb::kw(xb::mat._OutlineAlbedoTint)) {
         ol = ol * s.diffuse_color;
     }

--- a/crates/renderide/shaders/modules/xiexe_toon2_surface.wgsl
+++ b/crates/renderide/shaders/modules/xiexe_toon2_surface.wgsl
@@ -132,8 +132,9 @@ fn sample_surface(
     let uv_reflectivity = uvu::apply_st(xb::uv_select(uv_primary, uv_secondary, xb::mat._UVSetReflectivity), xb::mat._ReflectivityMask_ST);
     let uv_specular = uvu::apply_st(xb::uv_select(uv_primary, uv_secondary, xb::mat._UVSetSpecular), xb::mat._SpecularMap_ST);
 
-    var albedo = textureSample(xb::_MainTex, xb::_MainTex_sampler, uv_albedo) * xb::mat._Color;
-    let clip_alpha = xb::mat._Color.a * acs::texture_alpha_base_mip(xb::_MainTex, xb::_MainTex_sampler, uv_albedo);
+    let color_tint = vec4<f32>(xb::srgb_to_linear(xb::mat._Color.rgb), xb::mat._Color.a);
+    var albedo = textureSample(xb::_MainTex, xb::_MainTex_sampler, uv_albedo) * color_tint;
+    let clip_alpha = color_tint.a * acs::texture_alpha_base_mip(xb::_MainTex, xb::_MainTex_sampler, uv_albedo);
     if (xb::vertex_color_albedo_enabled()) {
         albedo = vec4<f32>(albedo.rgb * color.rgb, albedo.a);
     }
@@ -183,7 +184,7 @@ fn sample_surface(
     var occlusion = vec3<f32>(1.0);
     if (xb::occlusion_enabled()) {
         let occ = textureSample(xb::_OcclusionMap, xb::_OcclusionMap_sampler, uv_occlusion).r;
-        occlusion = mix(xb::mat._OcclusionColor.rgb, vec3<f32>(1.0), occ);
+        occlusion = mix(xb::srgb_to_linear(xb::mat._OcclusionColor.rgb), vec3<f32>(1.0), occ);
     }
 
     var emission = vec3<f32>(0.0);


### PR DESCRIPTION
Convert Xiexe Toon material color uniforms from sRGB to linear before lighting math so linear mode no longer appears brighter than expected. 

This makes it match how it is in unity

<img width="868" height="453" alt="image" src="https://github.com/user-attachments/assets/0c5313b9-c360-46d1-a64b-2af54159f6ca" />
