### PR TITLE
[Logger] Implements `log` facade to aggregate logs from dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1874,6 +1874,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 name = "logger"
 version = "0.1.0"
 dependencies = [
+ "log",
  "tempfile",
  "thiserror 2.0.18",
 ]
@@ -3088,6 +3089,7 @@ dependencies = [
  "thiserror 2.0.18",
  "toml 1.1.2+spec-1.1.0",
  "toml_edit 0.25.10+spec-1.1.0",
+ "tracing",
  "tracy-client",
  "unity-asset",
  "wgpu",
@@ -3784,6 +3786,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/crates/logger/Cargo.toml
+++ b/crates/logger/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 thiserror = "2.0"
+log = "0.4"
 
 [dev-dependencies]
 tempfile = "3.27"

--- a/crates/logger/src/level.rs
+++ b/crates/logger/src/level.rs
@@ -89,6 +89,30 @@ impl std::fmt::Display for LogLevel {
     }
 }
 
+impl From<log::Level> for LogLevel {
+    fn from(level: log::Level) -> LogLevel {
+        match level {
+            log::Level::Trace => LogLevel::Trace,
+            log::Level::Debug => LogLevel::Debug,
+            log::Level::Info => LogLevel::Info,
+            log::Level::Warn => LogLevel::Warn,
+            log::Level::Error => LogLevel::Error,
+        }
+    }
+}
+
+impl From<LogLevel> for log::LevelFilter {
+    fn from(level: LogLevel) -> log::LevelFilter {
+        match level {
+            LogLevel::Trace => log::LevelFilter::Trace,
+            LogLevel::Debug => log::LevelFilter::Debug,
+            LogLevel::Info => log::LevelFilter::Info,
+            LogLevel::Warn => log::LevelFilter::Warn,
+            LogLevel::Error => log::LevelFilter::Error,
+        }
+    }
+}
+
 /// Maps a stored `0..=4` tag back to [`LogLevel`]. Values above `4` clamp to [`LogLevel::Trace`].
 ///
 /// The forward direction is `level as u8`; this decoder is needed because `AtomicU8` storage can

--- a/crates/logger/src/output.rs
+++ b/crates/logger/src/output.rs
@@ -39,6 +39,34 @@ struct Logger {
     max_level: AtomicU8,
 }
 
+impl log::Log for Logger {
+    fn enabled(&self, metadata: &log::Metadata) -> bool {
+        let level: LogLevel = metadata.level().into();
+        let mut max_level = current_max_level(self);
+        if max_level == LogLevel::Debug && metadata.target().starts_with("naga") {
+            // naga's Debug messages ought to be Trace, really
+            max_level = LogLevel::Info;
+        }
+        level <= max_level
+    }
+
+    fn log(&self, record: &log::Record) {
+        if self.enabled(record.metadata()) {
+            let level: LogLevel = record.level().into();
+            with_line_buf(|buf| {
+                format_log_line_into(buf, record.target(), level, record.args().to_owned());
+                write_line_locked(self, level, buf.as_bytes());
+            });
+        }
+    }
+
+    fn flush(&self) {
+        if let Ok(mut file) = self.file.lock() {
+            let _ = file.flush();
+        }
+    }
+}
+
 #[derive(Clone, Copy)]
 struct MirrorWriter {
     max_level: LogLevel,
@@ -104,6 +132,11 @@ pub fn init_with_mirror(
         max_level: AtomicU8::new(max_level as u8),
     };
     let _ = LOGGER.set(logger);
+    if let Some(logger) = LOGGER.get() {
+        if let Ok(()) = log::set_logger(logger) {
+            log::set_max_level(max_level.into());
+        }
+    }
     Ok(())
 }
 
@@ -173,16 +206,23 @@ pub fn flush() {
     }
 }
 
-/// Writes a full log line into `out` in the canonical `[HH:MM:SS.mmm] LEVEL message\n` shape.
+/// Writes a full log line into `out` in the canonical `[HH:MM:SS.mmm] [TARGET] LEVEL message\n` shape.
 ///
 /// `out` is cleared first so the buffer can be reused across calls without observable carry-over.
-fn format_log_line_into(out: &mut String, level: LogLevel, args: std::fmt::Arguments<'_>) {
+fn format_log_line_into(
+    out: &mut String,
+    target: &str,
+    level: LogLevel,
+    args: std::fmt::Arguments<'_>,
+) {
     out.clear();
     if out.capacity() < LINE_BUF_INITIAL_CAPACITY {
         out.reserve(LINE_BUF_INITIAL_CAPACITY - out.capacity());
     }
     out.push('[');
     write_line_timestamp(out);
+    out.push_str("] [");
+    out.push_str(target);
     out.push_str("] ");
     out.push_str(level.as_label());
     out.push(' ');
@@ -238,7 +278,7 @@ pub fn log(level: LogLevel, args: std::fmt::Arguments<'_>) {
         return;
     }
     with_line_buf(|buf| {
-        format_log_line_into(buf, level, args);
+        format_log_line_into(buf, "renderide", level, args);
         write_line_locked(logger, level, buf.as_bytes());
     });
 }
@@ -264,7 +304,7 @@ pub fn try_log(level: LogLevel, args: std::fmt::Arguments<'_>) -> bool {
         return false;
     }
     with_line_buf(|buf| {
-        format_log_line_into(buf, level, args);
+        format_log_line_into(buf, "renderide", level, args);
         let bytes = buf.as_bytes();
         if let Ok(mut file) = logger.file.try_lock() {
             let _ = file.write_all(bytes);
@@ -351,16 +391,21 @@ mod tests {
     #[test]
     fn format_log_line_into_clears_existing_buffer_content() {
         let mut buf = String::from("stale_should_be_overwritten");
-        format_log_line_into(&mut buf, LogLevel::Info, format_args!("fresh_line"));
+        format_log_line_into(
+            &mut buf,
+            "renderide",
+            LogLevel::Info,
+            format_args!("fresh_line"),
+        );
         assert!(!buf.contains("stale_should_be_overwritten"));
-        assert!(buf.contains(" INFO fresh_line\n"));
+        assert!(buf.contains(" [renderide] INFO fresh_line\n"));
         assert!(buf.starts_with('['));
     }
 
     #[test]
     fn format_log_line_into_grows_capacity_to_initial() {
         let mut buf = String::new();
-        format_log_line_into(&mut buf, LogLevel::Trace, format_args!("x"));
+        format_log_line_into(&mut buf, "renderide", LogLevel::Trace, format_args!("x"));
         assert!(buf.capacity() >= LINE_BUF_INITIAL_CAPACITY);
     }
 
@@ -369,9 +414,18 @@ mod tests {
     #[test]
     fn format_log_line_into_emits_bracketed_timestamp_level_and_newline() {
         let mut buf = String::new();
-        format_log_line_into(&mut buf, LogLevel::Info, format_args!("hello_world"));
+        format_log_line_into(
+            &mut buf,
+            "renderide",
+            LogLevel::Info,
+            format_args!("hello_world"),
+        );
         assert!(buf.starts_with('['), "expected leading '[' in {buf:?}");
         assert!(buf.contains("] "), "expected '] ' separator in {buf:?}");
+        assert!(
+            buf.contains(" [renderide] "),
+            "expected ' [renderide] ' token in {buf:?}"
+        );
         assert!(buf.contains(" INFO "), "expected ' INFO ' token in {buf:?}");
         assert!(buf.contains("hello_world"), "expected message in {buf:?}");
         assert!(buf.ends_with('\n'), "expected trailing newline in {buf:?}");
@@ -388,7 +442,7 @@ mod tests {
     fn format_log_line_into_uses_correct_label_for_each_level() {
         let mut buf = String::new();
         for level in LogLevel::all() {
-            format_log_line_into(&mut buf, level, format_args!("body"));
+            format_log_line_into(&mut buf, "renderide", level, format_args!("body"));
             let token = format!(" {} body", level.as_label());
             assert!(
                 buf.contains(&token),
@@ -402,7 +456,7 @@ mod tests {
     #[test]
     fn format_log_line_into_handles_empty_message() {
         let mut buf = String::new();
-        format_log_line_into(&mut buf, LogLevel::Warn, format_args!(""));
+        format_log_line_into(&mut buf, "renderide", LogLevel::Warn, format_args!(""));
         assert!(buf.starts_with('['));
         assert!(buf.ends_with(" WARN \n"), "got {buf:?}");
         assert_eq!(buf.matches('\n').count(), 1);
@@ -414,7 +468,12 @@ mod tests {
     #[test]
     fn format_log_line_into_preserves_embedded_newlines() {
         let mut buf = String::new();
-        format_log_line_into(&mut buf, LogLevel::Error, format_args!("first\nsecond"));
+        format_log_line_into(
+            &mut buf,
+            "renderide",
+            LogLevel::Error,
+            format_args!("first\nsecond"),
+        );
         assert!(buf.contains("first\nsecond"), "got {buf:?}");
         assert!(buf.ends_with('\n'));
         assert_eq!(

--- a/crates/renderide/Cargo.toml
+++ b/crates/renderide/Cargo.toml
@@ -60,6 +60,7 @@ ahash = "0.8"
 bytemuck = { version = "1.25", features = ["derive"] }
 glam = { version = "0.32", features = ["bytemuck"] }
 logger = { path = "../logger" }
+tracing = { version = "0.1.44", features = ["log-always"] }
 renderide-shared = { path = "../renderide-shared" }
 interprocess = { path = "../interprocess" }
 pollster = "0.4"

--- a/crates/renderide/src/app/bootstrap/logging.rs
+++ b/crates/renderide/src/app/bootstrap/logging.rs
@@ -20,7 +20,11 @@ pub(crate) fn init_logging() -> Result<LoggingBootstrap, RunError> {
     let log_path = logger::init_for(LogComponent::Renderer, &timestamp, initial_log_level, false)
         .map_err(RunError::logging_init)?;
 
-    logger::info!("Logging to {}", log_path.display());
+    logger::info!(
+        "Logging to {} at max level {:?}",
+        log_path.display(),
+        initial_log_level
+    );
 
     crate::native_stdio::ensure_stdio_forwarded_to_logger();
     crate::fatal_crash_log::install(&log_path);


### PR DESCRIPTION
This is a small technical detail allowing us to gather logs from external crates into the logs created by Renderide.
In particular, this catches logs written by winit and wgpu.

From manual tests in a nominal use case, at the Info level, very few additional logs are written.
However, Debug and Trace can produce quite a few more log messages. In particular, naga produced a really egregious amount of Debug logs, so I manually relegated them to Trace (could be nice to make it more configurable in the future).