### PR TITLE
[Winit] Update to 0.31

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,11 +184,11 @@ dependencies = [
  "clipboard-win",
  "image",
  "log",
- "objc2 0.6.4",
- "objc2-app-kit 0.3.2",
+ "objc2",
+ "objc2-app-kit",
  "objc2-core-foundation",
  "objc2-core-graphics",
- "objc2-foundation 0.3.2",
+ "objc2-foundation",
  "parking_lot",
  "percent-encoding",
  "windows-sys 0.60.2",
@@ -344,20 +344,11 @@ dependencies = [
 
 [[package]]
 name = "block2"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
-dependencies = [
- "objc2 0.5.2",
-]
-
-[[package]]
-name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
- "objc2 0.6.4",
+ "objc2",
 ]
 
 [[package]]
@@ -377,6 +368,16 @@ dependencies = [
  "thiserror 2.0.18",
  "windows-sys 0.61.2",
  "winreg",
+]
+
+[[package]]
+name = "borsh"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
 ]
 
 [[package]]
@@ -446,26 +447,25 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "calloop"
-version = "0.13.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
+checksum = "4dbf9978365bac10f54d1d4b04f7ce4427e51f71d61f2fe15e3fed5166474df7"
 dependencies = [
  "bitflags 2.11.0",
- "log",
  "polling",
- "rustix 0.38.44",
+ "rustix",
  "slab",
- "thiserror 1.0.69",
+ "tracing",
 ]
 
 [[package]]
 name = "calloop-wayland-source"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
+checksum = "138efcf0940a02ebf0cc8d1eff41a1682a46b431630f4c52450d6265876021fa"
 dependencies = [
  "calloop",
- "rustix 0.38.44",
+ "rustix",
  "wayland-backend",
  "wayland-client",
 ]
@@ -613,46 +613,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "core-graphics"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "core-graphics-types",
- "foreign-types",
- "libc",
-]
-
-[[package]]
-name = "core-graphics-types"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "libc",
-]
-
-[[package]]
 name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -793,21 +753,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "dispatch"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
-
-[[package]]
 name = "dispatch2"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.11.0",
- "block2 0.6.2",
+ "block2",
  "libc",
- "objc2 0.6.4",
+ "objc2",
 ]
 
 [[package]]
@@ -952,33 +906,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
-name = "foreign-types"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
-dependencies = [
- "foreign-types-macros",
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-macros"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
-
-[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1070,7 +997,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
- "rustix 1.1.4",
+ "rustix",
  "windows-link",
 ]
 
@@ -1736,6 +1663,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyboard-types"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fbe853b403ae61a04233030ae8a79d94975281ed9770a1f9e246732b534b28d"
+dependencies = [
+ "bitflags 2.11.0",
+ "serde",
+]
+
+[[package]]
 name = "khronos-egl"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1836,12 +1773,6 @@ dependencies = [
  "plain",
  "redox_syscall 0.7.3",
 ]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2283,22 +2214,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc-sys"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
-
-[[package]]
-name = "objc2"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
-dependencies = [
- "objc-sys",
- "objc2-encode",
-]
-
-[[package]]
 name = "objc2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2309,67 +2224,16 @@ dependencies = [
 
 [[package]]
 name = "objc2-app-kit"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
-dependencies = [
- "bitflags 2.11.0",
- "block2 0.5.1",
- "libc",
- "objc2 0.5.2",
- "objc2-core-data",
- "objc2-core-image",
- "objc2-foundation 0.2.2",
- "objc2-quartz-core 0.2.2",
-]
-
-[[package]]
-name = "objc2-app-kit"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.11.0",
- "block2 0.6.2",
- "objc2 0.6.4",
+ "block2",
+ "objc2",
+ "objc2-core-foundation",
  "objc2-core-graphics",
- "objc2-foundation 0.3.2",
-]
-
-[[package]]
-name = "objc2-cloud-kit"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
-dependencies = [
- "bitflags 2.11.0",
- "block2 0.5.1",
- "objc2 0.5.2",
- "objc2-core-location",
- "objc2-foundation 0.2.2",
-]
-
-[[package]]
-name = "objc2-contacts"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889"
-dependencies = [
- "block2 0.5.1",
- "objc2 0.5.2",
- "objc2-foundation 0.2.2",
-]
-
-[[package]]
-name = "objc2-core-data"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
-dependencies = [
- "bitflags 2.11.0",
- "block2 0.5.1",
- "objc2 0.5.2",
- "objc2-foundation 0.2.2",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -2379,8 +2243,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.11.0",
+ "block2",
  "dispatch2",
- "objc2 0.6.4",
+ "objc2",
 ]
 
 [[package]]
@@ -2391,33 +2256,21 @@ checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
  "bitflags 2.11.0",
  "dispatch2",
- "objc2 0.6.4",
+ "libc",
+ "objc2",
  "objc2-core-foundation",
  "objc2-io-surface",
 ]
 
 [[package]]
-name = "objc2-core-image"
-version = "0.2.2"
+name = "objc2-core-video"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
+checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
 dependencies = [
- "block2 0.5.1",
- "objc2 0.5.2",
- "objc2-foundation 0.2.2",
- "objc2-metal 0.2.2",
-]
-
-[[package]]
-name = "objc2-core-location"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781"
-dependencies = [
- "block2 0.5.1",
- "objc2 0.5.2",
- "objc2-contacts",
- "objc2-foundation 0.2.2",
+ "bitflags 2.11.0",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
 ]
 
 [[package]]
@@ -2428,25 +2281,13 @@ checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "objc2-foundation"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
-dependencies = [
- "bitflags 2.11.0",
- "block2 0.5.1",
- "dispatch",
- "libc",
- "objc2 0.5.2",
-]
-
-[[package]]
-name = "objc2-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.0",
- "objc2 0.6.4",
+ "block2",
+ "objc2",
  "objc2-core-foundation",
 ]
 
@@ -2467,32 +2308,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
  "bitflags 2.11.0",
- "objc2 0.6.4",
+ "objc2",
  "objc2-core-foundation",
-]
-
-[[package]]
-name = "objc2-link-presentation"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
-dependencies = [
- "block2 0.5.1",
- "objc2 0.5.2",
- "objc2-app-kit 0.2.2",
- "objc2-foundation 0.2.2",
-]
-
-[[package]]
-name = "objc2-metal"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
-dependencies = [
- "bitflags 2.11.0",
- "block2 0.5.1",
- "objc2 0.5.2",
- "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -2502,22 +2319,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
 dependencies = [
  "bitflags 2.11.0",
- "block2 0.6.2",
- "objc2 0.6.4",
- "objc2-foundation 0.3.2",
-]
-
-[[package]]
-name = "objc2-quartz-core"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
-dependencies = [
- "bitflags 2.11.0",
- "block2 0.5.1",
- "objc2 0.5.2",
- "objc2-foundation 0.2.2",
- "objc2-metal 0.2.2",
+ "block2",
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -2527,65 +2331,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
  "bitflags 2.11.0",
- "objc2 0.6.4",
+ "objc2",
  "objc2-core-foundation",
- "objc2-foundation 0.3.2",
- "objc2-metal 0.3.2",
-]
-
-[[package]]
-name = "objc2-symbols"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a684efe3dec1b305badae1a28f6555f6ddd3bb2c2267896782858d5a78404dc"
-dependencies = [
- "objc2 0.5.2",
- "objc2-foundation 0.2.2",
+ "objc2-foundation",
+ "objc2-metal",
 ]
 
 [[package]]
 name = "objc2-ui-kit"
-version = "0.2.2"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
+checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
  "bitflags 2.11.0",
- "block2 0.5.1",
- "objc2 0.5.2",
- "objc2-cloud-kit",
- "objc2-core-data",
- "objc2-core-image",
- "objc2-core-location",
- "objc2-foundation 0.2.2",
- "objc2-link-presentation",
- "objc2-quartz-core 0.2.2",
- "objc2-symbols",
- "objc2-uniform-type-identifiers",
- "objc2-user-notifications",
-]
-
-[[package]]
-name = "objc2-uniform-type-identifiers"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe"
-dependencies = [
- "block2 0.5.1",
- "objc2 0.5.2",
- "objc2-foundation 0.2.2",
-]
-
-[[package]]
-name = "objc2-user-notifications"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
-dependencies = [
- "bitflags 2.11.0",
- "block2 0.5.1",
- "objc2 0.5.2",
- "objc2-core-location",
- "objc2-foundation 0.2.2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -2798,7 +2559,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix 1.1.4",
+ "rustix",
  "windows-sys 0.61.2",
 ]
 
@@ -2950,10 +2711,10 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40d213455a5f1dc59214213c7330e074ddf8114c9a42411eb890c767357ce135"
 dependencies = [
- "objc2 0.6.4",
+ "objc2",
  "objc2-core-foundation",
- "objc2-foundation 0.3.2",
- "objc2-quartz-core 0.3.2",
+ "objc2-foundation",
+ "objc2-quartz-core",
 ]
 
 [[package]]
@@ -2980,15 +2741,6 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
-dependencies = [
- "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -3137,15 +2889,15 @@ version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20dafead71c16a34e1ff357ddefc8afc11e7d51d6d2b9fbd07eaa48e3e540220"
 dependencies = [
- "block2 0.6.2",
+ "block2",
  "dispatch2",
  "js-sys",
  "libc",
  "log",
- "objc2 0.6.4",
- "objc2-app-kit 0.3.2",
+ "objc2",
+ "objc2-app-kit",
  "objc2-core-foundation",
- "objc2-foundation 0.3.2",
+ "objc2-foundation",
  "percent-encoding",
  "pollster",
  "raw-window-handle",
@@ -3181,19 +2933,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags 2.11.0",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -3201,7 +2940,7 @@ dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys 0.12.1",
+ "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
 
@@ -3258,9 +2997,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sctk-adwaita"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6277f0217056f77f1d8f49f2950ac6c278c0d607c45f5ee99328d792ede24ec"
+checksum = "1dd3accc0f3f4bbaf2c9e1957a030dc582028130c67660d44c0a0345a22ca69b"
 dependencies = [
  "ab_glyph",
  "log",
@@ -3463,9 +3202,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smithay-client-toolkit"
-version = "0.19.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
+checksum = "0512da38f5e2b31201a93524adb8d3136276fa4fe4aafab4e1f727a82b534cc0"
 dependencies = [
  "bitflags 2.11.0",
  "calloop",
@@ -3474,13 +3213,15 @@ dependencies = [
  "libc",
  "log",
  "memmap2",
- "rustix 0.38.44",
- "thiserror 1.0.69",
+ "rustix",
+ "thiserror 2.0.18",
  "wayland-backend",
  "wayland-client",
  "wayland-csd-frame",
  "wayland-cursor",
  "wayland-protocols",
+ "wayland-protocols-experimental",
+ "wayland-protocols-misc",
  "wayland-protocols-wlr",
  "wayland-scanner",
  "xkeysym",
@@ -3488,11 +3229,12 @@ dependencies = [
 
 [[package]]
 name = "smol_str"
-version = "0.2.2"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
+checksum = "4aaa7368fcf4852a4c2dd92df0cace6a71f2091ca0a23391ce7f3a31833f1523"
 dependencies = [
- "serde",
+ "borsh",
+ "serde_core",
 ]
 
 [[package]]
@@ -3575,7 +3317,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix 1.1.4",
+ "rustix",
  "windows-sys 0.61.2",
 ]
 
@@ -3784,6 +3526,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -4132,7 +3875,7 @@ checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
 dependencies = [
  "cc",
  "downcast-rs",
- "rustix 1.1.4",
+ "rustix",
  "scoped-tls",
  "smallvec",
  "wayland-sys",
@@ -4145,7 +3888,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
 dependencies = [
  "bitflags 2.11.0",
- "rustix 1.1.4",
+ "rustix",
  "wayland-backend",
  "wayland-scanner",
 ]
@@ -4167,7 +3910,7 @@ version = "0.31.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a52d18780be9b1314328a3de5f930b73d2200112e3849ca6cb11822793fb34d"
 dependencies = [
- "rustix 1.1.4",
+ "rustix",
  "wayland-client",
  "xcursor",
 ]
@@ -4181,6 +3924,32 @@ dependencies = [
  "bitflags 2.11.0",
  "wayland-backend",
  "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-experimental"
+version = "20250721.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40a1f863128dcaaec790d7b4b396cc9b9a7a079e878e18c47e6c2d2c5a8dcbb1"
+dependencies = [
+ "bitflags 2.11.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-misc"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e9567599ef23e09b8dad6e429e5738d4509dfc46b3b21f32841a304d16b29c8"
+dependencies = [
+ "bitflags 2.11.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
  "wayland-scanner",
 ]
 
@@ -4360,7 +4129,7 @@ dependencies = [
  "ash",
  "bit-set",
  "bitflags 2.11.0",
- "block2 0.6.2",
+ "block2",
  "bytemuck",
  "cfg-if",
  "cfg_aliases",
@@ -4377,11 +4146,11 @@ dependencies = [
  "mach-dxcompiler-rs",
  "naga",
  "ndk-sys",
- "objc2 0.6.4",
+ "objc2",
  "objc2-core-foundation",
- "objc2-foundation 0.3.2",
- "objc2-metal 0.3.2",
- "objc2-quartz-core 0.3.2",
+ "objc2-foundation",
+ "objc2-metal",
+ "objc2-quartz-core",
  "once_cell",
  "ordered-float",
  "parking_lot",
@@ -4593,15 +4362,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
@@ -4767,51 +4527,224 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winit"
-version = "0.30.13"
+version = "0.31.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6755fa58a9f8350bd1e472d4c3fcc25f824ec358933bba33306d0b63df5978d"
+checksum = "2879d2854d1a43e48f67322d4bd097afcb6eb8f8f775c8de0260a71aea1df1aa"
 dependencies = [
- "ahash",
- "android-activity",
- "atomic-waker",
  "bitflags 2.11.0",
- "block2 0.5.1",
- "bytemuck",
- "calloop",
  "cfg_aliases",
- "concurrent-queue",
- "core-foundation",
- "core-graphics",
  "cursor-icon",
  "dpi",
- "js-sys",
+ "libc",
+ "raw-window-handle",
+ "rustix",
+ "smol_str",
+ "tracing",
+ "winit-android",
+ "winit-appkit",
+ "winit-common",
+ "winit-core",
+ "winit-orbital",
+ "winit-uikit",
+ "winit-wayland",
+ "winit-web",
+ "winit-win32",
+ "winit-x11",
+]
+
+[[package]]
+name = "winit-android"
+version = "0.31.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d9c0d2cd93efec3a9f9ad819cfaf0834782403af7c0d248c784ec0c61761df"
+dependencies = [
+ "android-activity",
+ "bitflags 2.11.0",
+ "dpi",
+ "ndk",
+ "raw-window-handle",
+ "smol_str",
+ "tracing",
+ "winit-core",
+]
+
+[[package]]
+name = "winit-appkit"
+version = "0.31.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21310ca07851a49c348e0c2cc768e36b52ca65afda2c2354d78ed4b90074d8aa"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2",
+ "dispatch2",
+ "dpi",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-video",
+ "objc2-foundation",
+ "raw-window-handle",
+ "smol_str",
+ "tracing",
+ "winit-common",
+ "winit-core",
+]
+
+[[package]]
+name = "winit-common"
+version = "0.31.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45375fbac4cbb77260d83a30b1f9d8105880dbac99a9ae97f56656694680ff69"
+dependencies = [
+ "memmap2",
+ "objc2",
+ "objc2-core-foundation",
+ "smol_str",
+ "tracing",
+ "winit-core",
+ "x11-dl",
+ "xkbcommon-dl",
+]
+
+[[package]]
+name = "winit-core"
+version = "0.31.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4f0ccd7abb43740e2c6124ac7cae7d865ecec74eec63783e8922577ac232583"
+dependencies = [
+ "bitflags 2.11.0",
+ "cursor-icon",
+ "dpi",
+ "keyboard-types",
+ "raw-window-handle",
+ "smol_str",
+ "web-time",
+]
+
+[[package]]
+name = "winit-orbital"
+version = "0.31.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51ea1fb262e7209f265f12bd0cc792c399b14355675e65531e9c8a87db287d46"
+dependencies = [
+ "bitflags 2.11.0",
+ "dpi",
+ "orbclient",
+ "raw-window-handle",
+ "redox_syscall 0.5.18",
+ "smol_str",
+ "tracing",
+ "winit-core",
+]
+
+[[package]]
+name = "winit-uikit"
+version = "0.31.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680a356e798837d8eb274d4556e83bceaf81698194e31aafc5cfb8a9f2fab643"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2",
+ "dispatch2",
+ "dpi",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-ui-kit",
+ "raw-window-handle",
+ "smol_str",
+ "tracing",
+ "winit-common",
+ "winit-core",
+]
+
+[[package]]
+name = "winit-wayland"
+version = "0.31.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce5afb2ba07da603f84b722c95f9f9396d2cedae3944fb6c0cda4a6f88de545"
+dependencies = [
+ "ahash",
+ "bitflags 2.11.0",
+ "calloop",
+ "cursor-icon",
+ "dpi",
  "libc",
  "memmap2",
- "ndk",
- "objc2 0.5.2",
- "objc2-app-kit 0.2.2",
- "objc2-foundation 0.2.2",
- "objc2-ui-kit",
- "orbclient",
- "percent-encoding",
- "pin-project",
  "raw-window-handle",
- "redox_syscall 0.4.1",
- "rustix 0.38.44",
+ "rustix",
  "sctk-adwaita",
  "smithay-client-toolkit",
  "smol_str",
  "tracing",
- "unicode-segmentation",
- "wasm-bindgen",
- "wasm-bindgen-futures",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
  "wayland-protocols-plasma",
+ "winit-common",
+ "winit-core",
+]
+
+[[package]]
+name = "winit-web"
+version = "0.31.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c2490a953fb776fbbd5e295d54f1c3847f4f15b6c3929ec53c09acda6487a92"
+dependencies = [
+ "atomic-waker",
+ "bitflags 2.11.0",
+ "concurrent-queue",
+ "cursor-icon",
+ "dpi",
+ "js-sys",
+ "pin-project",
+ "raw-window-handle",
+ "smol_str",
+ "tracing",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
  "web-sys",
  "web-time",
- "windows-sys 0.52.0",
+ "winit-core",
+]
+
+[[package]]
+name = "winit-win32"
+version = "0.31.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "644ea78af0e858aa3b092e5d1c67c41995a98220c81813f1353b28bc8bb91eaa"
+dependencies = [
+ "bitflags 2.11.0",
+ "cursor-icon",
+ "dpi",
+ "raw-window-handle",
+ "smol_str",
+ "tracing",
+ "unicode-segmentation",
+ "windows-sys 0.59.0",
+ "winit-core",
+]
+
+[[package]]
+name = "winit-x11"
+version = "0.31.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa5b600756534c7041aa93cd0d244d44b09fca1b89e202bd1cd80dd9f3636c46"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytemuck",
+ "calloop",
+ "cursor-icon",
+ "dpi",
+ "libc",
+ "percent-encoding",
+ "raw-window-handle",
+ "rustix",
+ "smol_str",
+ "tracing",
+ "winit-common",
+ "winit-core",
  "x11-dl",
  "x11rb",
  "xkbcommon-dl",
@@ -4955,8 +4888,9 @@ dependencies = [
  "libc",
  "libloading 0.8.9",
  "once_cell",
- "rustix 1.1.4",
+ "rustix",
  "x11rb-protocol",
+ "xcursor",
 ]
 
 [[package]]

--- a/crates/renderide/Cargo.toml
+++ b/crates/renderide/Cargo.toml
@@ -83,7 +83,7 @@ notify = "8.2"
 naga = { version = "29.0", features = ["wgsl-in", "wgsl-out", "termcolor"] }
 unity-asset = "0.2"
 wgpu = "29.0"
-winit = "0.30"
+winit = "0.31.0-beta.2"
 ash = "0.38"
 openxr = { version = "0.21", default-features = false, features = ["loaded"] }
 imgui = { version = "0.12", features = ["tables-api"] }

--- a/crates/renderide/src/app/bootstrap.rs
+++ b/crates/renderide/src/app/bootstrap.rs
@@ -5,11 +5,14 @@ mod logging;
 mod runtime;
 pub(crate) mod services;
 
+use std::cell::RefCell;
+use std::rc::Rc;
+
 use winit::event_loop::EventLoop;
 
-use crate::connection::try_claim_renderer_singleton;
 use crate::ipc::get_headless_params;
 use crate::run_error::RunError;
+use crate::{app::exit::ExitState, connection::try_claim_renderer_singleton};
 
 use self::services::AppServices;
 use super::driver::AppDriver;
@@ -50,20 +53,23 @@ pub fn run() -> Result<RunExit, RunError> {
         RunError::event_loop_create(e)
     })?;
 
+    let exit_state = Rc::new(RefCell::new(ExitState::default()));
+
     let AppServices {
         external_shutdown,
         watchdog,
         main_heartbeat,
     } = services;
-    let mut app = AppDriver::new(
+    let app = AppDriver::new(
         runtime,
         app_config.gpu,
         logging.log_level_cli,
         external_shutdown,
         main_heartbeat,
+        exit_state.clone(),
     );
 
-    let _ = event_loop.run_app(&mut app);
+    let _ = event_loop.run_app(app);
     drop(watchdog);
-    Ok(app.into_run_exit())
+    Ok(exit_state.borrow().run_exit())
 }

--- a/crates/renderide/src/app/driver.rs
+++ b/crates/renderide/src/app/driver.rs
@@ -7,6 +7,8 @@ mod shutdown;
 mod target;
 mod xr;
 
+use std::cell::RefCell;
+use std::rc::Rc;
 use std::sync::atomic::Ordering;
 use std::time::{Duration, Instant};
 
@@ -23,7 +25,7 @@ use self::xr::XrInputCache;
 use super::bootstrap::{
     ExternalShutdownCoordinator, GpuStartupConfig, effective_renderer_log_level,
 };
-use super::exit::{ExitReason, ExitState, RunExit};
+use super::exit::{ExitReason, ExitState};
 use super::frame_clock::FrameClock;
 
 /// Interval between log flushes when using file logging in the winit handler.
@@ -35,7 +37,7 @@ pub(crate) struct AppDriver {
     startup_gpu: GpuStartupConfig,
     log_level_cli: Option<LogLevel>,
     target: Option<RenderTarget>,
-    exit: ExitState,
+    exit: Rc<RefCell<ExitState>>,
     log_flush: LogFlushCadence,
     shutdown: GracefulShutdown,
     input: WindowInputAccumulator,
@@ -56,13 +58,14 @@ impl AppDriver {
         log_level_cli: Option<LogLevel>,
         external_shutdown: Option<ExternalShutdownCoordinator>,
         main_heartbeat: Option<crate::diagnostics::Heartbeat>,
+        exit: Rc<RefCell<ExitState>>,
     ) -> Self {
         Self {
             runtime,
             startup_gpu,
             log_level_cli,
             target: None,
-            exit: ExitState::default(),
+            exit: exit,
             log_flush: LogFlushCadence::default(),
             shutdown: GracefulShutdown::default(),
             input: WindowInputAccumulator::default(),
@@ -75,14 +78,17 @@ impl AppDriver {
         }
     }
 
-    /// Returns the normal process exit requested by this app driver.
-    pub(crate) fn into_run_exit(self) -> RunExit {
-        self.exit.run_exit()
+    /// Returns whether an exit has already been requested.
+    pub(crate) fn exit_is_requested(&self) -> bool {
+        self.exit
+            .try_borrow()
+            .map(|exit_state| exit_state.is_requested())
+            .unwrap_or(true)
     }
 
-    fn request_exit(&mut self, reason: ExitReason, event_loop: &ActiveEventLoop) {
-        let first_request = !self.exit.is_requested();
-        let request = self.exit.request(reason);
+    fn request_exit(&mut self, reason: ExitReason, event_loop: &dyn ActiveEventLoop) {
+        let first_request = !self.exit_is_requested();
+        let request = self.exit.borrow_mut().request(reason);
         if !request.reason().uses_graceful_shutdown() {
             event_loop.exit();
             return;
@@ -97,7 +103,7 @@ impl AppDriver {
         self.poll_graceful_shutdown(event_loop);
     }
 
-    fn check_external_shutdown(&mut self, event_loop: &ActiveEventLoop) -> bool {
+    fn check_external_shutdown(&mut self, event_loop: &dyn ActiveEventLoop) -> bool {
         let Some(coord) = self.external_shutdown.as_ref() else {
             return false;
         };
@@ -111,7 +117,7 @@ impl AppDriver {
         true
     }
 
-    fn poll_graceful_shutdown(&mut self, event_loop: &ActiveEventLoop) -> bool {
+    fn poll_graceful_shutdown(&mut self, event_loop: &dyn ActiveEventLoop) -> bool {
         if !self.shutdown.is_started() {
             return false;
         }

--- a/crates/renderide/src/app/driver/events.rs
+++ b/crates/renderide/src/app/driver/events.rs
@@ -13,7 +13,7 @@ use super::super::frame_clock::{RedrawDecision, RedrawInputs, plan_redraw};
 use super::{AppDriver, RenderTarget};
 
 impl AppDriver {
-    fn ensure_render_target(&mut self, event_loop: &ActiveEventLoop) {
+    fn ensure_render_target(&mut self, event_loop: &dyn ActiveEventLoop) {
         if self.target.is_some() {
             return;
         }
@@ -39,9 +39,13 @@ impl AppDriver {
 }
 
 impl ApplicationHandler for AppDriver {
-    fn resumed(&mut self, event_loop: &ActiveEventLoop) {
+    fn can_create_surfaces(&mut self, event_loop: &dyn ActiveEventLoop) {
+        self.ensure_render_target(event_loop);
+    }
+
+    fn resumed(&mut self, event_loop: &dyn ActiveEventLoop) {
         profiling::scope!("app::resumed");
-        if self.exit.is_requested() {
+        if self.exit_is_requested() {
             return;
         }
         event_loop.listen_device_events(DeviceEvents::Always);
@@ -50,12 +54,12 @@ impl ApplicationHandler for AppDriver {
 
     fn device_event(
         &mut self,
-        _event_loop: &ActiveEventLoop,
-        _device_id: winit::event::DeviceId,
+        _event_loop: &dyn ActiveEventLoop,
+        _device_id: Option<winit::event::DeviceId>,
         event: DeviceEvent,
     ) {
         profiling::scope!("app::device_event");
-        if self.exit.is_requested() {
+        if self.exit_is_requested() {
             return;
         }
         apply_device_event(&mut self.input, &event);
@@ -63,7 +67,7 @@ impl ApplicationHandler for AppDriver {
 
     fn window_event(
         &mut self,
-        event_loop: &ActiveEventLoop,
+        event_loop: &dyn ActiveEventLoop,
         window_id: WindowId,
         event: WindowEvent,
     ) {
@@ -102,9 +106,9 @@ impl ApplicationHandler for AppDriver {
                 logger::info!("Window close requested");
                 self.request_exit(ExitReason::WindowClosed, event_loop);
             }
-            WindowEvent::Resized(size) => {
+            WindowEvent::SurfaceResized(size) => {
                 profiling::scope!("app::window_event_resize");
-                if !self.exit.is_requested()
+                if !self.exit_is_requested()
                     && let Some(target) = self.target.as_mut()
                 {
                     target.reconfigure_physical_size(size.width, size.height);
@@ -112,7 +116,7 @@ impl ApplicationHandler for AppDriver {
             }
             WindowEvent::RedrawRequested => {
                 profiling::scope!("app::redraw_requested");
-                if self.exit.is_requested() {
+                if self.exit_is_requested() {
                     self.poll_graceful_shutdown(event_loop);
                     self.flush_logs_if_due();
                     return;
@@ -126,7 +130,7 @@ impl ApplicationHandler for AppDriver {
             }
             WindowEvent::ScaleFactorChanged { .. } => {
                 profiling::scope!("app::window_event_scale_factor");
-                if !self.exit.is_requested()
+                if !self.exit_is_requested()
                     && let Some(target) = self.target.as_mut()
                 {
                     target.reconfigure_for_window();
@@ -138,10 +142,10 @@ impl ApplicationHandler for AppDriver {
         self.flush_logs_if_due();
     }
 
-    fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
+    fn about_to_wait(&mut self, event_loop: &dyn ActiveEventLoop) {
         profiling::scope!("app::about_to_wait");
         crate::profiling::plot_window_focused(self.input.window_focused);
-        if self.exit.is_requested() {
+        if self.exit_is_requested() {
             self.poll_graceful_shutdown(event_loop);
             self.flush_logs_if_due();
             return;
@@ -173,7 +177,7 @@ impl ApplicationHandler for AppDriver {
             .unwrap_or((0, 0));
         let plan = plan_redraw(RedrawInputs {
             has_window: self.target.is_some(),
-            exit_requested: self.exit.is_requested(),
+            exit_requested: self.exit_is_requested(),
             vr_active: self.runtime.vr_active(),
             window_focused: self.input.window_focused,
             focused_fps_cap,
@@ -199,7 +203,7 @@ impl ApplicationHandler for AppDriver {
             RedrawDecision::Idle => {}
         }
 
-        if !self.exit.is_requested() {
+        if !self.exit_is_requested() {
             event_loop.set_control_flow(ControlFlow::Poll);
         }
         self.flush_logs_if_due();

--- a/crates/renderide/src/app/driver/frame.rs
+++ b/crates/renderide/src/app/driver/frame.rs
@@ -51,7 +51,7 @@ pub(super) struct RenderViewsOutcome {
 
 impl AppDriver {
     /// One winit redraw tick.
-    pub(super) fn tick_frame(&mut self, event_loop: &ActiveEventLoop) {
+    pub(super) fn tick_frame(&mut self, event_loop: &dyn ActiveEventLoop) {
         profiling::scope!("tick::frame");
         let frame_start = Instant::now();
         if let Some(heartbeat) = self.main_heartbeat.as_ref() {
@@ -63,7 +63,7 @@ impl AppDriver {
 
     fn drive_frame_phases(
         &mut self,
-        event_loop: &ActiveEventLoop,
+        event_loop: &dyn ActiveEventLoop,
         frame_start: Instant,
     ) -> FrameTickOutcome {
         self.frame_tick_prologue(frame_start);
@@ -196,7 +196,7 @@ impl AppDriver {
         }
     }
 
-    fn handle_frame_exit_requests(&mut self, event_loop: &ActiveEventLoop) -> bool {
+    fn handle_frame_exit_requests(&mut self, event_loop: &dyn ActiveEventLoop) -> bool {
         if let Some(target) = self.target.as_ref()
             && let Some(session) = target.xr_session()
             && session.handles.xr_session.exit_requested()
@@ -223,7 +223,7 @@ impl AppDriver {
 
     fn render_views(
         &mut self,
-        window: &Arc<Window>,
+        window: &Arc<dyn Window>,
         xr_tick: Option<&OpenxrFrameTick>,
     ) -> Option<RenderViewsOutcome> {
         profiling::scope!("tick::render_views");

--- a/crates/renderide/src/app/driver/target.rs
+++ b/crates/renderide/src/app/driver/target.rs
@@ -4,8 +4,10 @@ use std::sync::Arc;
 
 use thiserror::Error;
 use winit::event_loop::ActiveEventLoop;
-use winit::window::{Fullscreen, Window};
+use winit::monitor::Fullscreen;
+use winit::window::{Window, WindowAttributes};
 
+use crate::frontend::input::enable_ime_on_window;
 use crate::frontend::output_device::head_output_device_wants_openxr;
 use crate::gpu::{GpuContext, GpuError};
 use crate::runtime::RendererRuntime;
@@ -19,7 +21,7 @@ use super::shutdown::GracefulShutdown;
 
 /// Fully initialized windowed render target.
 pub(super) struct RenderTarget {
-    window: Arc<Window>,
+    window: Arc<dyn Window>,
     gpu: GpuContext,
     output_device: HeadOutputDevice,
     mode: RenderTargetMode,
@@ -67,7 +69,7 @@ impl TargetInitError {
 impl RenderTarget {
     /// Creates the window, selects desktop vs OpenXR mode, and attaches the GPU to the runtime.
     pub(super) fn create(
-        event_loop: &ActiveEventLoop,
+        event_loop: &dyn ActiveEventLoop,
         runtime: &mut RendererRuntime,
         startup_gpu: GpuStartupConfig,
     ) -> Result<Self, TargetInitError> {
@@ -85,7 +87,7 @@ impl RenderTarget {
         };
 
         runtime.attach_gpu(&gpu);
-        window.set_ime_allowed(true);
+        enable_ime_on_window(window.as_ref());
 
         Ok(Self {
             window,
@@ -96,7 +98,7 @@ impl RenderTarget {
     }
 
     /// Main winit window.
-    pub(super) fn window(&self) -> &Arc<Window> {
+    pub(super) fn window(&self) -> &Arc<dyn Window> {
         &self.window
     }
 
@@ -216,8 +218,10 @@ fn poll_openxr_shutdown(
     xr_session.shutdown_quiesced()
 }
 
-fn create_main_window(event_loop: &ActiveEventLoop) -> Result<Arc<Window>, TargetInitError> {
-    let attrs = Window::default_attributes()
+fn create_main_window(
+    event_loop: &dyn ActiveEventLoop,
+) -> Result<Arc<dyn Window>, TargetInitError> {
+    let attrs = WindowAttributes::default()
         .with_title("Renderide")
         .with_maximized(true)
         .with_visible(true)
@@ -225,12 +229,12 @@ fn create_main_window(event_loop: &ActiveEventLoop) -> Result<Arc<Window>, Targe
 
     event_loop
         .create_window(attrs)
-        .map(Arc::new)
+        .map(Arc::from)
         .map_err(|error| TargetInitError::WindowCreate(error.to_string()))
 }
 
 fn create_desktop_target(
-    window: &Arc<Window>,
+    window: &Arc<dyn Window>,
     startup_gpu: GpuStartupConfig,
 ) -> Result<(GpuContext, RenderTargetMode), TargetInitError> {
     pollster::block_on(GpuContext::new(
@@ -249,7 +253,7 @@ fn create_desktop_target(
 }
 
 fn create_openxr_target(
-    window: &Arc<Window>,
+    window: &Arc<dyn Window>,
     startup_gpu: GpuStartupConfig,
 ) -> Result<(GpuContext, RenderTargetMode), TargetInitError> {
     if !startup_gpu.graphics_api.is_openxr_compatible() {
@@ -287,7 +291,7 @@ fn effective_output_device_for_gpu(pending: Option<&RendererInitData>) -> HeadOu
     pending.map_or(HeadOutputDevice::Screen, |init| init.output_device)
 }
 
-fn apply_window_title_from_init(window: &Arc<Window>, init: &RendererInitData) {
+fn apply_window_title_from_init(window: &Arc<dyn Window>, init: &RendererInitData) {
     if let Some(ref title) = init.window_title {
         window.set_title(title);
     }

--- a/crates/renderide/src/app/window_icon.rs
+++ b/crates/renderide/src/app/window_icon.rs
@@ -7,7 +7,7 @@
 //! way to supply a shell icon on many Linux desktops. On **macOS**, dock branding is primarily
 //! driven by bundle assets (e.g. `.icns`), not the window icon API.
 
-use winit::window::Icon;
+use winit::icon::{Icon, RgbaIcon};
 
 /// PNG bytes for [`try_embedded_window_icon`], resolved from this crate's manifest directory.
 const EMBEDDED_LOGO_PNG: &[u8] = include_bytes!(concat!(
@@ -28,8 +28,8 @@ pub(crate) fn try_embedded_window_icon() -> Option<Icon> {
     };
     let rgba = img.to_rgba8();
     let (width, height) = rgba.dimensions();
-    match Icon::from_rgba(rgba.into_raw(), width, height) {
-        Ok(icon) => Some(icon),
+    match RgbaIcon::new(rgba.into_raw(), width, height) {
+        Ok(icon) => Some(icon.into()),
         Err(e) => {
             logger::warn!("embedded window icon: winit rejected RGBA buffer: {e}");
             None

--- a/crates/renderide/src/diagnostics/input.rs
+++ b/crates/renderide/src/diagnostics/input.rs
@@ -63,7 +63,7 @@ impl DebugHudInput {
     /// Cursor is **`WindowInputAccumulator::window_position` (logical) x scale factor**, matching the
     /// swapchain / ImGui framebuffer in **physical** pixels.
     pub fn from_winit(
-        window: &winit::window::Window,
+        window: &dyn winit::window::Window,
         acc: &mut crate::frontend::input::WindowInputAccumulator,
     ) -> Self {
         let sf = window.scale_factor() as f32;

--- a/crates/renderide/src/frontend/input.rs
+++ b/crates/renderide/src/frontend/input.rs
@@ -10,6 +10,7 @@ mod winit;
 pub use accumulator::WindowInputAccumulator;
 pub use cursor::{
     CursorOutputTracking, apply_output_state_to_window, apply_per_frame_cursor_lock_when_locked,
+    enable_ime_on_window,
 };
 pub use vr_session::vr_inputs_for_session;
 pub use winit::{apply_device_event, apply_window_event};

--- a/crates/renderide/src/frontend/input/accumulator.rs
+++ b/crates/renderide/src/frontend/input/accumulator.rs
@@ -123,9 +123,9 @@ impl WindowInputAccumulator {
         self.last_cursor_pixel.y = position.y.round() as i32;
     }
 
-    /// Refreshes [`Self::window_resolution`] from [`Window::inner_size`] in **logical** pixels.
-    pub fn sync_window_resolution_logical(&mut self, window: &Window) {
-        let physical = window.inner_size();
+    /// Refreshes [`Self::window_resolution`] from [`Window::surface_size`] in **logical** pixels.
+    pub fn sync_window_resolution_logical(&mut self, window: &dyn Window) {
+        let physical = window.surface_size();
         let logical: LogicalSize<f64> = physical.to_logical(window.scale_factor());
         self.window_resolution = (logical.width.round() as u32, logical.height.round() as u32);
     }

--- a/crates/renderide/src/frontend/input/cursor.rs
+++ b/crates/renderide/src/frontend/input/cursor.rs
@@ -3,10 +3,11 @@
 use glam::IVec2;
 #[cfg(not(target_os = "macos"))]
 use glam::Vec2;
-use winit::dpi::LogicalPosition;
-#[cfg(not(target_os = "macos"))]
-use winit::dpi::LogicalSize;
-use winit::window::{CursorGrabMode, Window};
+use winit::dpi::{LogicalPosition, LogicalSize, Position};
+use winit::window::{
+    CursorGrabMode, ImeCapabilities, ImeEnableRequest, ImeHint, ImePurpose, ImeRequest,
+    ImeRequestData, Window,
+};
 
 use super::accumulator::WindowInputAccumulator;
 use crate::shared::OutputState;
@@ -19,10 +20,9 @@ pub struct CursorOutputTracking {
     last_lock_position: Option<IVec2>,
 }
 
-fn warp_cursor_logical(window: &Window, p: IVec2) -> Result<(), winit::error::ExternalError> {
+fn warp_cursor_logical(window: &dyn Window, p: IVec2) -> Result<(), winit::error::RequestError> {
     let logical = LogicalPosition::new(f64::from(p.x), f64::from(p.y));
-    let physical = logical.to_physical::<f64>(window.scale_factor());
-    window.set_cursor_position(physical)
+    window.set_cursor_position(Position::Logical(logical))
 }
 
 /// Reapplies grab and warp **every frame** while the host requests cursor lock: the cursor is
@@ -32,10 +32,10 @@ fn warp_cursor_logical(window: &Window, p: IVec2) -> Result<(), winit::error::Ex
 /// look and IPC [`crate::shared::MouseState::window_position`] stay aligned with the OS cursor.
 #[cfg(not(target_os = "macos"))]
 pub fn apply_per_frame_cursor_lock_when_locked(
-    window: &Window,
+    window: &dyn Window,
     acc: &mut WindowInputAccumulator,
     lock_cursor_position: Option<IVec2>,
-) -> Result<(), winit::error::ExternalError> {
+) -> Result<(), winit::error::RequestError> {
     let sf = window.scale_factor();
     acc.sync_window_resolution_logical(window);
 
@@ -51,13 +51,12 @@ pub fn apply_per_frame_cursor_lock_when_locked(
             .set_cursor_grab(CursorGrabMode::Locked)
             .or_else(|_| window.set_cursor_grab(CursorGrabMode::Confined))?;
         window.set_cursor_visible(false);
-        let physical = window.inner_size();
+        let physical = window.surface_size();
         let logical_sz: LogicalSize<f64> = physical.to_logical(sf);
         let cx = (logical_sz.width / 2.0) as f32;
         let cy = (logical_sz.height / 2.0) as f32;
         let logical_center = LogicalPosition::new(f64::from(cx), f64::from(cy));
-        let phys_center = logical_center.to_physical::<f64>(sf);
-        window.set_cursor_position(phys_center)?;
+        window.set_cursor_position(Position::Logical(logical_center))?;
         acc.set_window_position_from_logical(Vec2::new(cx, cy), sf);
     }
     Ok(())
@@ -70,10 +69,10 @@ pub fn apply_per_frame_cursor_lock_when_locked(
 /// [`apply_output_state_to_window`]; only continuous re-centering is omitted.
 #[cfg(target_os = "macos")]
 pub fn apply_per_frame_cursor_lock_when_locked(
-    _window: &Window,
+    _window: &dyn Window,
     _acc: &mut WindowInputAccumulator,
     _lock_cursor_position: Option<IVec2>,
-) -> Result<(), winit::error::ExternalError> {
+) -> Result<(), winit::error::RequestError> {
     Ok(())
 }
 
@@ -81,11 +80,19 @@ pub fn apply_per_frame_cursor_lock_when_locked(
 /// [`apply_per_frame_cursor_lock_when_locked`] each frame while locked for continuous re-centering
 /// (a no-op on macOS; see that function's documentation).
 pub fn apply_output_state_to_window(
-    window: &Window,
+    window: &dyn Window,
     state: &OutputState,
     track: &mut CursorOutputTracking,
-) -> Result<(), winit::error::ExternalError> {
-    window.set_ime_allowed(state.keyboard_input_active);
+) -> Result<(), winit::error::RequestError> {
+    if state.keyboard_input_active {
+        if let None = window.ime_capabilities() {
+            enable_ime_on_window(window);
+        }
+    } else {
+        if let Some(_) = window.ime_capabilities() {
+            let _ = window.request_ime_update(ImeRequest::Disable);
+        }
+    }
 
     if let Some(p) = state.lock_cursor_position {
         let _ = warp_cursor_logical(window, p);
@@ -122,4 +129,18 @@ pub fn apply_output_state_to_window(
         let _ = warp_cursor_logical(window, p);
     }
     Ok(())
+}
+
+pub fn enable_ime_on_window(window: &dyn Window) {
+    // Pretty much a copy of the deprecatied Window::set_ime_allowed(true)
+    let position = LogicalPosition::new(0, 0);
+    let size = LogicalSize::new(0, 0);
+    let ime_caps = ImeCapabilities::new()
+        .with_hint_and_purpose()
+        .with_cursor_area();
+    let request_data = ImeRequestData::default()
+        .with_hint_and_purpose(ImeHint::NONE, ImePurpose::Normal)
+        .with_cursor_area(position.into(), size.into());
+    let action = ImeRequest::Enable(ImeEnableRequest::new(ime_caps, request_data).unwrap());
+    let _ = window.request_ime_update(action);
 }

--- a/crates/renderide/src/frontend/input/event_transition.rs
+++ b/crates/renderide/src/frontend/input/event_transition.rs
@@ -60,7 +60,7 @@ pub(crate) fn mouse_button_transition(
         MouseButton::Middle => MouseButtonSlot::Middle,
         MouseButton::Back => MouseButtonSlot::Button4,
         MouseButton::Forward => MouseButtonSlot::Button5,
-        MouseButton::Other(_) => return None,
+        _ => return None,
     };
     Some(MouseButtonTransition {
         slot,
@@ -123,7 +123,7 @@ mod tests {
             mouse_button_transition(ElementState::Pressed, MouseButton::Back).expect("mapped");
         assert_eq!(transition.slot, MouseButtonSlot::Button4);
         assert!(transition.pressed);
-        assert!(mouse_button_transition(ElementState::Pressed, MouseButton::Other(9)).is_none());
+        assert!(mouse_button_transition(ElementState::Pressed, MouseButton::Button9).is_none());
     }
 
     #[test]

--- a/crates/renderide/src/frontend/input/key_map.rs
+++ b/crates/renderide/src/frontend/input/key_map.rs
@@ -127,8 +127,8 @@ fn map_keycode_nav_function_modifiers(code: KeyCode) -> Option<Key> {
         KeyCode::ControlRight => Key::RightControl,
         KeyCode::AltLeft => Key::LeftAlt,
         KeyCode::AltRight => Key::RightAlt,
-        KeyCode::SuperLeft => Key::LeftWindows,
-        KeyCode::SuperRight => Key::RightWindows,
+        KeyCode::MetaLeft => Key::LeftWindows,
+        KeyCode::MetaRight => Key::RightWindows,
         KeyCode::Delete => Key::Delete,
         KeyCode::PrintScreen => Key::Print,
         KeyCode::Pause => Key::Pause,
@@ -301,8 +301,8 @@ mod tests {
             (KeyCode::ControlRight, Key::RightControl),
             (KeyCode::AltLeft, Key::LeftAlt),
             (KeyCode::AltRight, Key::RightAlt),
-            (KeyCode::SuperLeft, Key::LeftWindows),
-            (KeyCode::SuperRight, Key::RightWindows),
+            (KeyCode::MetaLeft, Key::LeftWindows),
+            (KeyCode::MetaRight, Key::RightWindows),
         ] {
             assert_eq!(
                 winit_key_to_renderite_key(PhysicalKey::Code(code)),

--- a/crates/renderide/src/frontend/input/winit.rs
+++ b/crates/renderide/src/frontend/input/winit.rs
@@ -4,7 +4,8 @@ use std::path::Path;
 
 use winit::dpi::LogicalSize;
 use winit::event::{
-    DeviceEvent, ElementState, Ime, KeyEvent, MouseButton, MouseScrollDelta, WindowEvent,
+    ButtonSource, DeviceEvent, ElementState, Ime, KeyEvent, MouseButton, MouseScrollDelta,
+    WindowEvent,
 };
 use winit::window::Window;
 
@@ -18,9 +19,13 @@ use super::event_transition::{
 ///
 /// [`WindowEvent::Resized`], [`WindowEvent::ScaleFactorChanged`], and cursor move use the same
 /// **logical** pixel space as [`WindowInputAccumulator::window_position`].
-pub fn apply_window_event(acc: &mut WindowInputAccumulator, window: &Window, event: &WindowEvent) {
+pub fn apply_window_event(
+    acc: &mut WindowInputAccumulator,
+    window: &dyn Window,
+    event: &WindowEvent,
+) {
     match event {
-        WindowEvent::Resized(size) => {
+        WindowEvent::SurfaceResized(size) => {
             profiling::scope!("frontend::window_event", "resize");
             let logical: LogicalSize<f64> = size.to_logical(window.scale_factor());
             acc.window_resolution = (logical.width.round() as u32, logical.height.round() as u32);
@@ -29,15 +34,15 @@ pub fn apply_window_event(acc: &mut WindowInputAccumulator, window: &Window, eve
             profiling::scope!("frontend::window_event", "scale_factor");
             acc.sync_window_resolution_logical(window);
         }
-        WindowEvent::CursorMoved { position, .. } => {
+        WindowEvent::PointerMoved { position, .. } => {
             profiling::scope!("frontend::window_event", "cursor_moved");
             acc.set_cursor_from_physical(*position, window.scale_factor());
         }
-        WindowEvent::CursorEntered { .. } => {
+        WindowEvent::PointerEntered { .. } => {
             profiling::scope!("frontend::window_event", "cursor_entered");
             acc.mouse_active = true;
         }
-        WindowEvent::CursorLeft { .. } => {
+        WindowEvent::PointerLeft { .. } => {
             profiling::scope!("frontend::window_event", "cursor_left");
             acc.mouse_active = false;
         }
@@ -52,9 +57,11 @@ pub fn apply_window_event(acc: &mut WindowInputAccumulator, window: &Window, eve
             profiling::scope!("frontend::window_event", "modifiers");
             acc.set_keyboard_modifiers(modifiers.state());
         }
-        WindowEvent::MouseInput { state, button, .. } => {
+        WindowEvent::PointerButton { state, button, .. } => {
             profiling::scope!("frontend::window_event", "mouse_button");
-            apply_mouse_button(acc, *state, *button);
+            if let ButtonSource::Mouse(mouse_button) = button {
+                apply_mouse_button(acc, *state, *mouse_button);
+            }
         }
         WindowEvent::MouseWheel { delta, .. } => {
             profiling::scope!("frontend::window_event", "scroll");
@@ -75,12 +82,17 @@ pub fn apply_window_event(acc: &mut WindowInputAccumulator, window: &Window, eve
             profiling::scope!("frontend::window_event", "ime");
             match ime {
                 Ime::Commit(s) => acc.push_ime_commit(s.as_str()),
-                Ime::Enabled | Ime::Disabled | Ime::Preedit(_, _) => {}
+                Ime::Enabled
+                | Ime::Disabled
+                | Ime::Preedit(_, _)
+                | Ime::DeleteSurrounding { .. } => {}
             }
         }
-        WindowEvent::DroppedFile(path) => {
+        WindowEvent::DragDropped { paths, .. } => {
             profiling::scope!("frontend::window_event", "dropped_file");
-            acc.push_dropped_file_path(path_to_string_lossy(path));
+            for path in paths {
+                acc.push_dropped_file_path(path_to_string_lossy(path));
+            }
         }
         _ => {}
     }
@@ -135,7 +147,7 @@ fn path_to_string_lossy(path: &Path) -> String {
 
 /// Applies relative pointer motion when the cursor is captured (locked / confined).
 pub fn apply_device_event(acc: &mut WindowInputAccumulator, event: &DeviceEvent) {
-    if let DeviceEvent::MouseMotion { delta } = event {
+    if let DeviceEvent::PointerMotion { delta } = event {
         profiling::scope!("frontend::device_event", "mouse_motion");
         acc.mouse_delta.x += delta.0 as f32;
         acc.mouse_delta.y -= delta.1 as f32;

--- a/crates/renderide/src/gpu/context.rs
+++ b/crates/renderide/src/gpu/context.rs
@@ -83,9 +83,9 @@ pub struct GpuContext {
     /// reconfigures the swapchain at runtime. Empty in headless mode (no surface, no caps to query).
     supported_present_modes: Vec<wgpu::PresentMode>,
     /// Window the surface was created from, kept so swapchain Lost/Outdated recovery can call
-    /// [`Window::inner_size`] without threading `&Window` through every render-path signature.
+    /// [`Window::surface_size`] without threading `&Window` through every render-path signature.
     /// [`None`] in headless mode (no winit window exists).
-    window: Option<Arc<Window>>,
+    window: Option<Arc<dyn Window>>,
     /// Depth target matching [`Self::config`] extent; recreated after resize.
     depth_attachment: Option<(wgpu::Texture, wgpu::TextureView)>,
     depth_extent_px: (u32, u32),

--- a/crates/renderide/src/gpu/context/init.rs
+++ b/crates/renderide/src/gpu/context/init.rs
@@ -78,7 +78,7 @@ struct GpuContextParts {
     /// Surface present modes.
     supported_present_modes: Vec<wgpu::PresentMode>,
     /// Optional window owner.
-    window: Option<Arc<Window>>,
+    window: Option<Arc<dyn Window>>,
 }
 
 /// Windowed adapter-selection result before device creation.
@@ -132,7 +132,7 @@ fn assemble_context(parts: GpuContextParts) -> GpuContext {
 }
 
 async fn select_window_adapter_with_fallback(
-    window: &Arc<Window>,
+    window: &Arc<dyn Window>,
     graphics_api: GraphicsApiSetting,
     gpu_validation_layers: bool,
     power_preference: wgpu::PowerPreference,
@@ -164,7 +164,7 @@ async fn select_window_adapter_with_fallback(
 }
 
 async fn select_window_adapter(
-    window: &Arc<Window>,
+    window: &Arc<dyn Window>,
     graphics_api: GraphicsApiSetting,
     gpu_validation_layers: bool,
     power_preference: wgpu::PowerPreference,
@@ -172,7 +172,7 @@ async fn select_window_adapter(
     let (instance, instance_flags, active_backends) =
         build_wgpu_instance(gpu_validation_layers, graphics_api.requested_backends());
 
-    // `Arc<Window>` is `Into<SurfaceTarget<'static>>`, so the returned `Surface` is
+    // `Arc<dyn Window>` is `Into<SurfaceTarget<'static>>`, so the returned `Surface` is
     // already `'static` -- no `transmute` is required to extend the borrow.
     let surface: wgpu::Surface<'static> = instance
         .create_surface(Arc::clone(window))
@@ -251,7 +251,7 @@ impl GpuContext {
     /// explicit API is retried with [`GraphicsApiSetting::Auto`] when it finds no compatible
     /// adapter. The final backend set may still be overridden by `WGPU_BACKEND`.
     pub async fn new(
-        window: Arc<Window>,
+        window: Arc<dyn Window>,
         vsync: VsyncMode,
         max_frame_latency: u32,
         gpu_validation_layers: bool,
@@ -272,7 +272,7 @@ impl GpuContext {
         let (device, queue) = request_device_for_adapter(&adapter, required_features).await?;
 
         let limits = GpuLimits::try_new(device.as_ref(), &adapter)?;
-        let size = window.inner_size();
+        let size = window.surface_size();
         let supported_present_modes = surface_safe.get_capabilities(&adapter).present_modes;
         let mut config = surface_safe
             .get_default_config(&adapter, size.width.max(1), size.height.max(1))
@@ -455,17 +455,17 @@ impl GpuContext {
         adapter: &wgpu::Adapter,
         device: Arc<wgpu::Device>,
         queue: Arc<wgpu::Queue>,
-        window: Arc<Window>,
+        window: Arc<dyn Window>,
         vsync: VsyncMode,
         max_frame_latency: u32,
     ) -> Result<Self, GpuError> {
         install_uncaptured_error_handler(device.as_ref());
-        // `Arc<Window>` is `Into<SurfaceTarget<'static>>`, so the returned `Surface` is
+        // `Arc<dyn Window>` is `Into<SurfaceTarget<'static>>`, so the returned `Surface` is
         // already `'static` -- no `transmute` is required to extend the borrow.
         let surface_safe: wgpu::Surface<'static> = instance
             .create_surface(window.clone())
             .map_err(|e| GpuError::Surface(format!("{e:?}")))?;
-        let size = window.inner_size();
+        let size = window.surface_size();
         let supported_present_modes = surface_safe.get_capabilities(adapter).present_modes;
         let mut config = surface_safe
             .get_default_config(adapter, size.width.max(1), size.height.max(1))

--- a/crates/renderide/src/gpu/context/surface.rs
+++ b/crates/renderide/src/gpu/context/surface.rs
@@ -54,14 +54,14 @@ impl GpuContext {
         self.surface.is_none()
     }
 
-    /// Live `inner_size` of the window stored inside this context, if windowed.
+    /// Live `surface_size` of the window stored inside this context, if windowed.
     ///
     /// Re-queries the window each call so callers handling `WindowEvent::ScaleFactorChanged` can
-    /// pick up the new logical size without holding a separate `Arc<Window>`. Returns [`None`] in
+    /// pick up the new logical size without holding a separate `Arc<dyn Window>`. Returns [`None`] in
     /// headless mode.
     pub fn window_inner_size(&self) -> Option<(u32, u32)> {
         self.window.as_ref().map(|w| {
-            let s = w.inner_size();
+            let s = w.surface_size();
             (s.width, s.height)
         })
     }
@@ -94,7 +94,7 @@ impl GpuContext {
             | wgpu::CurrentSurfaceTexture::Suboptimal(t) => Ok(t),
             wgpu::CurrentSurfaceTexture::Lost | wgpu::CurrentSurfaceTexture::Outdated => {
                 logger::info!("surface Lost or Outdated -- reconfiguring");
-                let size = self.window.as_ref().map(|w| w.inner_size());
+                let size = self.window.as_ref().map(|w| w.surface_size());
                 if let Some(s) = size {
                     self.reconfigure(s.width, s.height);
                 }

--- a/crates/renderide/src/reflection_probes/task_rows.rs
+++ b/crates/renderide/src/reflection_probes/task_rows.rs
@@ -77,6 +77,7 @@ pub(super) fn write_task_answer(bytes: &mut [u8], offset: usize, answer: TaskAns
 
 /// Debug helper that asserts every active row has been moved out of `Scheduled`.
 pub(super) fn debug_assert_no_scheduled_rows(bytes: &[u8]) {
+    let _ = bytes;
     #[cfg(debug_assertions)]
     {
         const RESULT_OFFSET: usize = std::mem::offset_of!(ReflectionProbeSH2Task, result);


### PR DESCRIPTION
There are quite a few very interesting additions in winit 0.31, in particular a large number of additions to the Wayland implementation (this is where my bias comes in, I suppose :sweat_smile: )

There are a handful of breaking changes in the crate’s API:
- Some structs are now traits (Window, ActiveEventLoop), references to them had to be converted to &dyn
- event_loop::run_app now takes ownership of the app driver, instead of a mut ref, which required a small refactoring to retrieve the exit state with a RefCell
- A few symbols were renamed

I have tested this successfully on Linux, but someone needs to confirm that Windows still behaves as expected.