### PR TITLE
[Projection 360] Fix lerping without secondary texture

### DIFF
--- a/crates/renderide/src/materials/embedded/uniform_pack/tables.rs
+++ b/crates/renderide/src/materials/embedded/uniform_pack/tables.rs
@@ -572,9 +572,9 @@ fn xiexe_transparent_on_inferred(
 /// | `OUTSIDE_CLAMP`   | `OutsideMode.Value == Outside.Clamp` (no wire signal)  | partial `_FOV` (full-sphere `(TAU, PI)` keeps default) |
 /// | `CUBEMAP_LOD`     | cubemap target + `CubemapLOD.Value.HasValue`           | `_MainCube`/`_SecondCube` texture + `_CubeLOD`        |
 /// | `CUBEMAP`         | cubemap target + no LOD                                | `_MainCube`/`_SecondCube` texture, no `_CubeLOD`      |
-/// | `SECOND_TEXTURE`  | `SecondaryTexture/Cubemap` set or `TextureLerp != 0`   | `_SecondTex`/`_SecondCube` texture                    |
+/// | `SECOND_TEXTURE`  | `SecondaryTexture/Cubemap` set and `TextureLerp != 0`  | `_SecondTex`/`_SecondCube` texture                    |
 /// | `_OFFSET`         | `OffsetTexture.Asset != null`                          | `_OffsetTex` texture                                  |
-/// | `_CLAMP_INTENSITY`| `MaxIntensity.HasValue || HDR texture`                 | `_MaxIntensity` written (only sent when enabled)      |
+/// | `_CLAMP_INTENSITY`| `MaxIntensity.HasValue`                                | `_MaxIntensity` written (only sent when enabled)      |
 /// | `TINT_TEX_LERP`   | `TintTexture` + `TintTextureMode == Lerp`              | `_TintTex` texture + `_Tint0` written (Lerp-only send)|
 /// | `TINT_TEX_DIRECT` | `TintTexture` + `TintTextureMode == Direct`            | `_TintTex` texture, no `_Tint0`                       |
 ///
@@ -631,7 +631,7 @@ fn projection360_keyword_inferred(
         "_PERSPECTIVE" => uniform_written("_PerspectiveFOV"),
         "CUBEMAP_LOD" => cubemap_present && cube_lod_written,
         "CUBEMAP" => cubemap_present && !cube_lod_written,
-        "SECOND_TEXTURE" => secondary_texture_present || texture_lerp_nonzero,
+        "SECOND_TEXTURE" => secondary_texture_present && texture_lerp_nonzero,
         "_OFFSET" => texture_property_present_pids(store, lookup, &[kw.offset_tex]),
         "_CLAMP_INTENSITY" => uniform_written("_MaxIntensity"),
         "TINT_TEX_LERP" => tint_tex_present && tint0_written,

--- a/crates/renderide/src/materials/embedded/uniform_pack/tests/projection360.rs
+++ b/crates/renderide/src/materials/embedded/uniform_pack/tests/projection360.rs
@@ -255,7 +255,7 @@ fn projection360_cubemap_with_cube_lod_enables_cubemap_lod_keyword() {
     );
 }
 
-/// Secondary 2D texture bound on `_SecondTex` enables `SECOND_TEXTURE`.
+/// Secondary 2D texture bound on `_SecondTex` and `TextureLerp != 0` enables `SECOND_TEXTURE`.
 #[test]
 fn projection360_secondary_texture_enables_second_texture_keyword() {
     let mut store = MaterialPropertyStore::new();
@@ -270,28 +270,13 @@ fn projection360_secondary_texture_enables_second_texture_keyword() {
             crate::assets::texture::HostTextureAssetKind::Texture2D,
         )),
     );
-    assert_eq!(
-        inferred_keyword_float_f32("SECOND_TEXTURE", &store, lookup(44), &ids),
-        Some(1.0)
-    );
-}
-
-/// `TextureLerp != 0` on its own enables `SECOND_TEXTURE` (mirrors the host's
-/// `state2 = ... || TextureLerp.Value != 0f` predicate). Even without a secondary
-/// asset, the host turns on the keyword so the shader's lerp branch runs.
-#[test]
-fn projection360_nonzero_texture_lerp_enables_second_texture_keyword() {
-    let mut store = MaterialPropertyStore::new();
-    let reg = PropertyIdRegistry::new();
-    let ids = projection360_ids(&reg);
-    set_full_sphere_fov(&mut store, &reg, 45);
     store.set_material(
-        45,
+        44,
         reg.intern("_TextureLerp"),
         MaterialPropertyValue::Float(0.5),
     );
     assert_eq!(
-        inferred_keyword_float_f32("SECOND_TEXTURE", &store, lookup(45), &ids),
+        inferred_keyword_float_f32("SECOND_TEXTURE", &store, lookup(44), &ids),
         Some(1.0)
     );
 }
@@ -317,7 +302,7 @@ fn projection360_offset_texture_enables_offset_keyword() {
     );
 }
 
-/// `_MaxIntensity` is sent only when `MaxIntensity.HasValue || HDR texture` -- its
+/// `_MaxIntensity` is sent only when `MaxIntensity.HasValue` -- its
 /// presence drives `_CLAMP_INTENSITY`.
 #[test]
 fn projection360_max_intensity_present_enables_clamp_intensity_keyword() {


### PR DESCRIPTION
As it stands, if a TextureLerp value > 0 is provided without a defined SecondaryTexture, Renderide performs a lerp which causes the material to shine in an extremely bright white color.
The reference renderer seems to just ignore the lerp parameter when SecondaryTexture is undefined, so Renderide should do the same.