### PR TITLE
Default configs to user dirs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1431,6 +1431,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2845,6 +2854,7 @@ dependencies = [
  "tracy-client",
  "unity-asset",
  "unity-asset-binary",
+ "user_dirs",
  "wgpu",
  "wgpu-profiler",
  "wide 1.4.0",
@@ -3722,6 +3732,15 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "user_dirs"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e0d5bff51f431ac0e51881aa83a00d96561878caca262c04157857a4b02083"
+dependencies = [
+ "home",
+]
 
 [[package]]
 name = "utf8parse"

--- a/crates/renderide/Cargo.toml
+++ b/crates/renderide/Cargo.toml
@@ -112,6 +112,7 @@ tracy-client = { version = "0.18", optional = true, default-features = false, fe
 ## upload paths are stubbed and the host sees a static black placeholder.
 gstreamer = { version = "0.25", optional = true }
 gstreamer-app = { version = "0.25", optional = true }
+user_dirs = "0.2.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 wgpu = { version = "29.0", features = ["vulkan-portability"] }

--- a/crates/renderide/src/config/persist/resolve.rs
+++ b/crates/renderide/src/config/persist/resolve.rs
@@ -2,6 +2,8 @@
 
 use std::path::{Path, PathBuf};
 
+use user_dirs;
+
 #[cfg(test)]
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -31,6 +33,7 @@ pub struct ConfigResolveOutcome {
 
 /// Canonical on-disk config file (TOML).
 pub const FILE_NAME_TOML: &str = "config.toml";
+
 const ENV_OVERRIDE: &str = "RENDERIDE_CONFIG";
 
 fn push_toml_candidate(out: &mut Vec<PathBuf>, dir: &Path) {
@@ -132,6 +135,13 @@ pub fn apply_generated_config(outcome: &mut ConfigResolveOutcome, path: PathBuf)
 fn search_candidates() -> Vec<PathBuf> {
     let mut v = Vec::new();
 
+    if let Some(dir) = user_dirs::config_dir().ok() {
+        push_toml_candidate(&mut v, dir.join("Renderide").as_path());
+        if let Some(parent) = dir.parent() {
+            push_toml_candidate(&mut v, parent);
+        }
+    }
+
     if let Some(dir) = binary_output_dir() {
         push_toml_candidate(&mut v, dir.as_path());
         if let Some(parent) = dir.parent() {
@@ -218,6 +228,12 @@ pub fn read_config_file(path: &Path) -> std::io::Result<String> {
 pub fn resolve_save_path(resolve: &ConfigResolveOutcome) -> PathBuf {
     if let Some(p) = resolve.loaded_path.clone() {
         return p;
+    }
+
+    if let Some(dir) = user_dirs::config_dir().ok()
+        && is_dir_writable(dir.as_path())
+    {
+        return dir.join("Renderide/".to_owned() + FILE_NAME_TOML);
     }
 
     if let Some(dir) = binary_output_dir()


### PR DESCRIPTION
This changes the default location to create, read and write the config file to the user's config directories, making use of the user_dirs crate. By default, these are the directories that it will try to work with:
- XDG (if set): `$XDG_CONFIG_HOME/Renderide`
- Linux: `/home/USER/.config/Renderide`
- Windows: `C:\Users\USER\AppData\Roaming\Renderide`

The existing behavior was not removed or replaced, but simply now a lower priority as there is still utility in the old behavior.

As a side note, I am still very new to rust, so feel free to point out things that need to be fixed as I am unfamiliar with best practices.