### PR TITLE
Rename output bins

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Prerequisites: a Vulkan-, Metal-, or DirectX 12-capable GPU and a Steam installa
 1. Run the bootstrapper:
 
    ```bash
-   ./target/release/bootstrapper
+   ./target/release/renderide
    ```
 
 The bootstrapper will launch the Resonite host and connect Renderide automatically.

--- a/crates/bootstrapper/Cargo.toml
+++ b/crates/bootstrapper/Cargo.toml
@@ -8,7 +8,7 @@ description = "ResoBoot-aligned process bootstrap: spawns Renderite Host, IPC qu
 path = "src/lib.rs"
 
 [[bin]]
-name = "bootstrapper"
+name = "renderide"
 path = "src/main.rs"
 
 [dependencies]

--- a/crates/bootstrapper/src/config.rs
+++ b/crates/bootstrapper/src/config.rs
@@ -80,7 +80,7 @@ impl ResoBootConfig {
             .unwrap_or_else(|| current_directory.clone());
         let renderite_directory = exe_dir.clone();
         let renderite_executable = exe_dir.join(if cfg!(windows) {
-            "renderide.exe"
+            "renderide-renderer.exe"
         } else {
             "Renderite.Renderer"
         });
@@ -152,7 +152,7 @@ mod tests {
             .and_then(|n| n.to_str())
             .expect("file name");
         if cfg!(windows) {
-            assert_eq!(exe_name, "renderide.exe");
+            assert_eq!(exe_name, "renderide-renderer.exe");
         } else {
             assert_eq!(exe_name, "Renderite.Renderer");
         }

--- a/crates/bootstrapper/src/renderer_link.rs
+++ b/crates/bootstrapper/src/renderer_link.rs
@@ -22,7 +22,7 @@ pub fn ensure_link(config: &ResoBootConfig) {
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     {
         let symlink = &config.renderite_executable;
-        let target = config.renderite_directory.join("renderide");
+        let target = config.renderite_directory.join("renderide-renderer");
         let needs_renderer_stub = target.exists() && {
             #[cfg(target_os = "linux")]
             {
@@ -75,7 +75,7 @@ mod tests {
         let tmp = std::env::temp_dir().join(format!("bootstrapper_stub_{}", std::process::id()));
         let _ = fs::remove_dir_all(&tmp);
         fs::create_dir_all(&tmp).unwrap();
-        let target = tmp.join("renderide");
+        let target = tmp.join("renderide-renderer");
         fs::write(&target, b"").unwrap();
         let link = tmp.join("Renderite.Renderer");
         let c = cfg_with_dirs(&tmp, &link);
@@ -91,7 +91,7 @@ mod tests {
         let tmp = std::env::temp_dir().join(format!("bootstrapper_stub2_{}", std::process::id()));
         let _ = fs::remove_dir_all(&tmp);
         fs::create_dir_all(&tmp).unwrap();
-        let target = tmp.join("renderide");
+        let target = tmp.join("renderide-renderer");
         fs::write(&target, b"").unwrap();
         let link = tmp.join("Renderite.Renderer");
         std::os::unix::fs::symlink(tmp.join("wrong"), &link).unwrap();
@@ -145,7 +145,7 @@ mod tests_macos {
             std::env::temp_dir().join(format!("bootstrapper_stub_mac_{}", std::process::id()));
         let _ = fs::remove_dir_all(&tmp);
         fs::create_dir_all(&tmp).unwrap();
-        let target = tmp.join("renderide");
+        let target = tmp.join("renderide-renderer");
         fs::write(&target, b"bin").unwrap();
         let link = tmp.join("Renderite.Renderer");
         let c = cfg_with_dirs(&tmp, &link);

--- a/crates/renderide-test/src/cli.rs
+++ b/crates/renderide-test/src/cli.rs
@@ -236,9 +236,9 @@ impl BuildProfile {
 
 fn default_renderer_path(profile: BuildProfile) -> PathBuf {
     let exe = if cfg!(windows) {
-        "renderide.exe"
+        "renderide-renderer.exe"
     } else {
-        "renderide"
+        "renderide-renderer"
     };
     PathBuf::from("target").join(profile.target_dir()).join(exe)
 }
@@ -267,9 +267,9 @@ fn renderide_next_to_this_test_binary() -> Option<PathBuf> {
         return None;
     }
     let candidate = profile_dir.join(if cfg!(windows) {
-        "renderide.exe"
+        "renderide-renderer.exe"
     } else {
-        "renderide"
+        "renderide-renderer"
     });
     candidate.is_file().then_some(candidate)
 }
@@ -344,9 +344,9 @@ mod cli_tests {
 
     fn expected_exe() -> &'static str {
         if cfg!(windows) {
-            "renderide.exe"
+            "renderide-renderer.exe"
         } else {
-            "renderide"
+            "renderide-renderer"
         }
     }
 }

--- a/crates/renderide-test/src/host/scene_session/spawn.rs
+++ b/crates/renderide-test/src/host/scene_session/spawn.rs
@@ -81,7 +81,7 @@ mod tests {
 
     fn minimal_config() -> SceneSessionConfig {
         SceneSessionConfig {
-            renderer_path: PathBuf::from("target/debug/renderide"),
+            renderer_path: PathBuf::from("target/debug/renderide-renderer"),
             output_path: PathBuf::from("target/headless.png"),
             width: 64,
             height: 32,

--- a/crates/renderide/Cargo.toml
+++ b/crates/renderide/Cargo.toml
@@ -15,7 +15,7 @@ naga_oil = { version = "0.22", default-features = false }
 thiserror = "2"
 
 [[bin]]
-name = "renderide"
+name = "renderide-renderer"
 path = "src/main.rs"
 
 [[bin]]


### PR DESCRIPTION
This changes the `bootstrapper` binary to be named `renderide`, and the `renderide` binary to be named `renderide-renderer`.

This is to simplify CLI usage and packaging.

I also changed the bootstrapper to create a symlink targeting the renamed binary, as it otherwise recursively launches itself. I also tweaked the windows target exe, assuming that also needs to be changed. If it does not, I can revert the windows part.