### PR TITLE
Fix XSToon Emission applying when it shouldn't

### DIFF
--- a/crates/renderide/shaders/modules/xiexe/toon2/variant_bits.wgsl
+++ b/crates/renderide/shaders/modules/xiexe/toon2/variant_bits.wgsl
@@ -203,23 +203,14 @@ fn normal_map_enabled_for_layout(keyword_layout: u32) -> bool {
     return kw_NORMAL_MAP_for_layout(keyword_layout);
 }
 
-/// True when the emission term should be evaluated for this material. Mirrors the
-/// `EMISSION_MAP` keyword and falls back to a non-black `_EmissionColor` so materials that
-/// drive emission purely through the color slider still light up.
+/// True when the emission term should be evaluated for this material.
 fn emission_map_enabled() -> bool {
     return emission_map_enabled_for_layout(XTOON_KEYWORD_LAYOUT_GENERIC);
 }
 
 /// True when the emission term should be evaluated for a selected keyword layout.
 fn emission_map_enabled_for_layout(keyword_layout: u32) -> bool {
-    if (kw_EMISSION_MAP_for_layout(keyword_layout)) {
-        return true;
-    }
-    if (static_vertexlight_layout(keyword_layout)) {
-        return false;
-    }
-    let c = xb::mat._EmissionColor.rgb;
-    return dot(c, c) > 1e-8;
+    return kw_EMISSION_MAP_for_layout(keyword_layout);
 }
 
 /// True when the metallic-gloss map should be sampled (expanded from `OCCLUSION_METALLIC`).

--- a/crates/renderide/tests/shader_module_audit/xiexe_and_probes.rs
+++ b/crates/renderide/tests/shader_module_audit/xiexe_and_probes.rs
@@ -330,7 +330,6 @@ fn xiexe_static_stems_use_static_vertexlight_keyword_layout() -> io::Result<()> 
     for required in [
         "fn normal_map_enabled_for_layout(keyword_layout: u32) -> bool",
         "fn emission_map_enabled_for_layout(keyword_layout: u32) -> bool",
-        "if (static_vertexlight_layout(keyword_layout)) {\n        return false;\n    }\n    let c = xb::mat._EmissionColor.rgb;",
         "fn matcap_enabled_for_layout(keyword_layout: u32) -> bool",
         "fn reflection_uses_pbr_for_layout(keyword_layout: u32) -> bool",
     ] {


### PR DESCRIPTION
XSToon emission keyword shouldn't be falling back to if _EmissionColor is non zero.
FrooxEngine only set the EMISSION_MAP keyword base on if the texture is assigned and the shader only reads _EmissionMap and _EmissionColor if EMISSION_MAP is set.

This fixes some of my materials being pure white, they had no emission texture, but the emission color was left as white.

https://github.com/Yellow-Dog-Man/Resonite.UnityShaders/blob/main/Assets/Shaders/Xiexes/Main/CGIncludes/XSFrag.cginc#L69-L71