### PR TITLE
[Color space] Use gamma 2.2 curve for uniform color parameters with channels > 1

### DIFF
--- a/crates/renderide-shared/src/shared.rs
+++ b/crates/renderide-shared/src/shared.rs
@@ -4316,15 +4316,7 @@ impl MemoryPackable for GaussianRotationFormat {
         unpacker: &mut MemoryUnpacker<'_, '_, P>,
     ) -> Result<(), WireDecodeError> {
         let raw = unpacker.read::<i32>()?;
-        *self = if raw == 0 {
-            Self::PackedNorm10
-        } else {
-            trace!(
-                "invalid GaussianRotationFormat wire value {}; using default",
-                raw
-            );
-            Self::PackedNorm10
-        };
+        *self = Self::from_i32(raw);
         Ok(())
     }
 }

--- a/crates/renderide/src/color_space.rs
+++ b/crates/renderide/src/color_space.rs
@@ -4,9 +4,8 @@ use glam::{Vec3, Vec4};
 
 /// Converts one sRGB channel to linear-light space.
 ///
-/// Values outside the display `[0, 1]` interval keep the host's signed HDR-style magnitude:
-/// negative channels are converted by absolute value and sign is restored, while channels above
-/// `1.0` pass through unchanged.
+/// All positive values keep the host's signed HDR-style magnitude,
+/// while negative channels are converted by absolute value and sign is restored.
 pub(crate) fn srgb_channel_to_linear(mut value: f32) -> f32 {
     let sign = if value < 0.0 {
         value = -value;
@@ -14,9 +13,7 @@ pub(crate) fn srgb_channel_to_linear(mut value: f32) -> f32 {
     } else {
         1.0
     };
-    let linear = if value >= 1.0 {
-        value
-    } else if value <= 0.04045 {
+    let linear = if value <= 0.04045 {
         value / 12.92
     } else {
         ((value + 0.055) / 1.055).powf(2.4)
@@ -61,7 +58,7 @@ mod tests {
     fn srgb_channel_conversion_matches_elements_material_profile_rules() {
         assert!((srgb_channel_to_linear(0.5) - 0.214_041_14).abs() < EPS);
         assert!((srgb_channel_to_linear(0.04045) - (0.04045 / 12.92)).abs() < EPS);
-        assert_eq!(srgb_channel_to_linear(1.25), 1.25);
+        assert!((srgb_channel_to_linear(1.25) - 1.66594).abs() < EPS);
         assert!((srgb_channel_to_linear(-0.5) - -0.214_041_14).abs() < EPS);
     }
 
@@ -71,7 +68,7 @@ mod tests {
 
         assert!((linear.x - 0.214_041_14).abs() < EPS);
         assert!((linear.y - (0.04045 / 12.92)).abs() < EPS);
-        assert_eq!(linear.z, 1.25);
+        assert!((linear.z - 1.66594).abs() < EPS);
         assert_eq!(linear.w, 0.33);
     }
 
@@ -81,7 +78,7 @@ mod tests {
 
         assert!((linear[0] - -0.214_041_14).abs() < EPS);
         assert!((linear[1] - (0.04045 / 12.92)).abs() < EPS);
-        assert_eq!(linear[2], 1.25);
+        assert!((linear[2] - 1.66594).abs() < EPS);
         assert_eq!(linear[3], 0.33);
     }
 }

--- a/crates/renderide/src/color_space.rs
+++ b/crates/renderide/src/color_space.rs
@@ -4,8 +4,9 @@ use glam::{Vec3, Vec4};
 
 /// Converts one sRGB channel to linear-light space.
 ///
-/// All positive values keep the host's signed HDR-style magnitude,
-/// while negative channels are converted by absolute value and sign is restored.
+/// All positive values within [0, 1] are converted using the sRGB curve.
+/// Negative channels are converted by absolute value and sign is restored.
+/// Values greater than 1 are converted using a gamma 2.2 curve (to match the Unity renderer's behavior).
 pub(crate) fn srgb_channel_to_linear(mut value: f32) -> f32 {
     let sign = if value < 0.0 {
         value = -value;
@@ -13,7 +14,9 @@ pub(crate) fn srgb_channel_to_linear(mut value: f32) -> f32 {
     } else {
         1.0
     };
-    let linear = if value <= 0.04045 {
+    let linear = if value >= 1.0 {
+        value.powf(2.2)
+    } else if value <= 0.04045 {
         value / 12.92
     } else {
         ((value + 0.055) / 1.055).powf(2.4)
@@ -58,7 +61,7 @@ mod tests {
     fn srgb_channel_conversion_matches_elements_material_profile_rules() {
         assert!((srgb_channel_to_linear(0.5) - 0.214_041_14).abs() < EPS);
         assert!((srgb_channel_to_linear(0.04045) - (0.04045 / 12.92)).abs() < EPS);
-        assert!((srgb_channel_to_linear(1.25) - 1.66594).abs() < EPS);
+        assert!((srgb_channel_to_linear(1.25) - 1.633_811_8).abs() < EPS);
         assert!((srgb_channel_to_linear(-0.5) - -0.214_041_14).abs() < EPS);
     }
 
@@ -68,7 +71,7 @@ mod tests {
 
         assert!((linear.x - 0.214_041_14).abs() < EPS);
         assert!((linear.y - (0.04045 / 12.92)).abs() < EPS);
-        assert!((linear.z - 1.66594).abs() < EPS);
+        assert!((linear.z - 1.633_811_8).abs() < EPS);
         assert_eq!(linear.w, 0.33);
     }
 
@@ -78,7 +81,7 @@ mod tests {
 
         assert!((linear[0] - -0.214_041_14).abs() < EPS);
         assert!((linear[1] - (0.04045 / 12.92)).abs() < EPS);
-        assert!((linear[2] - 1.66594).abs() < EPS);
+        assert!((linear[2] - 1.633_811_8).abs() < EPS);
         assert_eq!(linear[3], 0.33);
     }
 }

--- a/crates/renderide/src/frontend/input/winit.rs
+++ b/crates/renderide/src/frontend/input/winit.rs
@@ -87,15 +87,9 @@ pub fn apply_window_event(
             }
             apply_keyboard_event(acc, event);
         }
-        WindowEvent::Ime(ime) => {
+        WindowEvent::Ime(Ime::Commit(s)) => {
             profiling::scope!("frontend::window_event", "ime");
-            match ime {
-                Ime::Commit(s) => acc.push_ime_commit(s.as_str()),
-                Ime::Enabled
-                | Ime::Disabled
-                | Ime::Preedit(_, _)
-                | Ime::DeleteSurrounding { .. } => {}
-            }
+            acc.push_ime_commit(s.as_str());
         }
         WindowEvent::DragDropped { paths, position } => {
             profiling::scope!("frontend::window_event", "dropped_file");

--- a/crates/renderide/src/materials/embedded/uniform_pack/color_space.rs
+++ b/crates/renderide/src/materials/embedded/uniform_pack/color_space.rs
@@ -163,7 +163,7 @@ mod tests {
 
         assert!((linear[0] - -0.214_041_14).abs() < 0.000_001);
         assert!((linear[1] - (0.04045 / 12.92)).abs() < 0.000_001);
-        assert_eq!(linear[2], 1.25);
+        assert!((linear[2] - 1.66594).abs() < 0.000_001);
         assert_eq!(linear[3], 0.33);
     }
 

--- a/crates/renderide/src/materials/embedded/uniform_pack/color_space.rs
+++ b/crates/renderide/src/materials/embedded/uniform_pack/color_space.rs
@@ -163,7 +163,7 @@ mod tests {
 
         assert!((linear[0] - -0.214_041_14).abs() < 0.000_001);
         assert!((linear[1] - (0.04045 / 12.92)).abs() < 0.000_001);
-        assert!((linear[2] - 1.66594).abs() < 0.000_001);
+        assert!((linear[2] - 1.633_811_8).abs() < 0.000_001);
         assert_eq!(linear[3], 0.33);
     }
 

--- a/crates/renderide/src/scene/blit_to_display.rs
+++ b/crates/renderide/src/scene/blit_to_display.rs
@@ -192,7 +192,7 @@ mod tests {
         let color = space.blit_to_displays[0].state.background_color;
         assert!((color.x - 0.214_041_14).abs() < 0.000_001);
         assert!((color.y - (0.04045 / 12.92)).abs() < 0.000_001);
-        assert_eq!(color.z, 1.25);
+        assert!((color.z - 1.66594).abs() < 0.000_001);
         assert_eq!(color.w, 0.33);
     }
 }

--- a/crates/renderide/src/scene/blit_to_display.rs
+++ b/crates/renderide/src/scene/blit_to_display.rs
@@ -192,7 +192,7 @@ mod tests {
         let color = space.blit_to_displays[0].state.background_color;
         assert!((color.x - 0.214_041_14).abs() < 0.000_001);
         assert!((color.y - (0.04045 / 12.92)).abs() < 0.000_001);
-        assert!((color.z - 1.66594).abs() < 0.000_001);
+        assert!((color.z - 1.633_811_8).abs() < 0.000_001);
         assert_eq!(color.w, 0.33);
     }
 }

--- a/crates/renderide/src/scene/camera.rs
+++ b/crates/renderide/src/scene/camera.rs
@@ -231,7 +231,7 @@ mod tests {
         let color = space.cameras[0].state.background_color;
         assert!((color.x - 0.214_041_14).abs() < 0.000_001);
         assert!((color.y - (0.04045 / 12.92)).abs() < 0.000_001);
-        assert!((color.z - 1.66594).abs() < 0.000_001);
+        assert!((color.z - 1.633_811_8).abs() < 0.000_001);
         assert_eq!(color.w, 0.33);
     }
 

--- a/crates/renderide/src/scene/camera.rs
+++ b/crates/renderide/src/scene/camera.rs
@@ -231,7 +231,7 @@ mod tests {
         let color = space.cameras[0].state.background_color;
         assert!((color.x - 0.214_041_14).abs() < 0.000_001);
         assert!((color.y - (0.04045 / 12.92)).abs() < 0.000_001);
-        assert_eq!(color.z, 1.25);
+        assert!((color.z - 1.66594).abs() < 0.000_001);
         assert_eq!(color.w, 0.33);
     }
 

--- a/crates/renderide/src/scene/lights/cache/tests.rs
+++ b/crates/renderide/src/scene/lights/cache/tests.rs
@@ -9,6 +9,7 @@ use super::LightCache;
 const EPS: f32 = 0.000_001;
 const SRGB_HALF_LINEAR: f32 = 0.214_041_14;
 const SRGB_THRESHOLD_LINEAR: f32 = 0.04045 / 12.92;
+const SRGB_ONE_AND_A_QUARTER_LINEAR: f32 = 1.66594;
 
 fn assert_close(actual: f32, expected: f32) {
     assert!(
@@ -83,7 +84,7 @@ fn store_full_linearizes_submitted_light_colors() {
     assert_eq!(lights.len(), 1);
     assert_close(lights[0].data.color.x, SRGB_HALF_LINEAR);
     assert_close(lights[0].data.color.y, SRGB_THRESHOLD_LINEAR);
-    assert_eq!(lights[0].data.color.z, 1.25);
+    assert_close(lights[0].data.color.z, SRGB_ONE_AND_A_QUARTER_LINEAR);
     assert_eq!(lights[0].data.intensity, 1.0);
     assert_eq!(lights[0].data.range, 10.0);
 }
@@ -238,7 +239,7 @@ fn regular_light_update_linearizes_state_color() {
     assert_eq!(lights.len(), 1);
     assert_close(lights[0].data.color.x, SRGB_HALF_LINEAR);
     assert_close(lights[0].data.color.y, SRGB_THRESHOLD_LINEAR);
-    assert_eq!(lights[0].data.color.z, 1.25);
+    assert_close(lights[0].data.color.z, SRGB_ONE_AND_A_QUARTER_LINEAR);
     assert_eq!(lights[0].data.intensity, 2.0);
     assert_eq!(lights[0].data.range, 30.0);
     assert_eq!(lights[0].state.shadow_strength, 0.5);

--- a/crates/renderide/src/scene/lights/cache/tests.rs
+++ b/crates/renderide/src/scene/lights/cache/tests.rs
@@ -9,7 +9,7 @@ use super::LightCache;
 const EPS: f32 = 0.000_001;
 const SRGB_HALF_LINEAR: f32 = 0.214_041_14;
 const SRGB_THRESHOLD_LINEAR: f32 = 0.04045 / 12.92;
-const SRGB_ONE_AND_A_QUARTER_LINEAR: f32 = 1.66594;
+const SRGB_ONE_AND_A_QUARTER_LINEAR: f32 = 1.633_811_8;
 
 fn assert_close(actual: f32, expected: f32) {
     assert!(

--- a/crates/renderide/src/scene/reflection_probe.rs
+++ b/crates/renderide/src/scene/reflection_probe.rs
@@ -269,7 +269,7 @@ mod tests {
         let color = space.reflection_probes[0].state.background_color;
         assert!((color.x - 0.214_041_14).abs() < 0.000_001);
         assert!((color.y - (0.04045 / 12.92)).abs() < 0.000_001);
-        assert_eq!(color.z, 1.25);
+        assert!((color.z - 1.66594).abs() < 0.000_001);
         assert_eq!(color.w, 0.33);
     }
 

--- a/crates/renderide/src/scene/reflection_probe.rs
+++ b/crates/renderide/src/scene/reflection_probe.rs
@@ -269,7 +269,7 @@ mod tests {
         let color = space.reflection_probes[0].state.background_color;
         assert!((color.x - 0.214_041_14).abs() < 0.000_001);
         assert!((color.y - (0.04045 / 12.92)).abs() < 0.000_001);
-        assert!((color.z - 1.66594).abs() < 0.000_001);
+        assert!((color.z - 1.633_811_8).abs() < 0.000_001);
         assert_eq!(color.w, 0.33);
     }
 


### PR DESCRIPTION
From my tests, it seems likely that when FrooxEngine converts colors to SRGB before sending them through IPC, it does not apply any falloff for channels with values greater than one.
For this reason, reverting the inverse falloff on this side when re-converting to linear solves the color discrepancy that has been observed in #390 and #389 .
@fulgenscode I’d be glad for you to try this branch out and see if it fixes your issue as well!