### PR TITLE
Remove a few string copies by using Cow<str> instead of String.

### DIFF
--- a/crates/renderide-shared/src/shared.rs
+++ b/crates/renderide-shared/src/shared.rs
@@ -17,6 +17,8 @@
     reason = "generated code: lints enforced on hand-written code do not apply here"
 )]
 
+use std::borrow::Cow;
+
 use super::buffer::SharedMemoryBufferDescriptor;
 use super::packing::enum_repr::EnumRepr;
 use super::packing::memory_packable::MemoryPackable;
@@ -915,9 +917,9 @@ impl MemoryPackable for RendererInitData {
 #[derive(Debug, Default, Clone)]
 pub struct RendererInitResult {
     pub actual_output_device: HeadOutputDevice,
-    pub renderer_identifier: Option<String>,
+    pub renderer_identifier: Option<Cow<'static, str>>,
     pub main_window_handle_ptr: i64,
-    pub stereo_rendering_mode: Option<String>,
+    pub stereo_rendering_mode: Option<Cow<'static, str>>,
     pub max_texture_size: i32,
     pub is_gpu_texture_pot_byte_aligned: bool,
     pub supported_texture_formats: Vec<TextureFormat>,
@@ -938,9 +940,9 @@ impl MemoryPackable for RendererInitResult {
         unpacker: &mut MemoryUnpacker<'_, '_, P>,
     ) -> Result<(), WireDecodeError> {
         unpacker.read_object_required(&mut self.actual_output_device)?;
-        self.renderer_identifier = unpacker.read_str()?;
+        self.renderer_identifier = unpacker.read_str()?.map(<_>::into);
         self.main_window_handle_ptr = unpacker.read()?;
-        self.stereo_rendering_mode = unpacker.read_str()?;
+        self.stereo_rendering_mode = unpacker.read_str()?.map(<_>::into);
         self.max_texture_size = unpacker.read()?;
         self.is_gpu_texture_pot_byte_aligned = unpacker.read_bool()?;
         self.supported_texture_formats = unpacker.read_enum_value_list()?;

--- a/crates/renderide/src/frontend/dispatch/ipc_init.rs
+++ b/crates/renderide/src/frontend/dispatch/ipc_init.rs
@@ -1,6 +1,6 @@
 //! Pure IPC command routing by [`crate::frontend::InitState`].
 
-use std::sync::LazyLock;
+use std::borrow::Cow;
 
 use crate::frontend::InitState;
 use crate::shared::{
@@ -17,15 +17,18 @@ use super::renderer_command_kind::renderer_command_variant_tag;
 /// The commit suffix is supplied by `build.rs` via the `RENDERIDE_GIT_COMMIT`
 /// rustc env var; an empty value means git was unavailable at build time and
 /// the suffix is omitted.
-static RENDERER_IDENTIFIER: LazyLock<String> = LazyLock::new(|| {
-    let version = env!("CARGO_PKG_VERSION");
-    let commit = env!("RENDERIDE_GIT_COMMIT");
-    if commit.is_empty() {
-        format!("Renderide {version}")
+const RENDERER_IDENTIFIER: &str = const {
+    if env!("RENDERIDE_GIT_COMMIT").is_empty() {
+        concat!("Renderide ", env!("CARGO_PKG_VERSION"))
     } else {
-        format!("Renderide {version}-{commit}")
+        concat!(
+            "Renderide ",
+            env!("CARGO_PKG_VERSION"),
+            "-",
+            env!("RENDERIDE_GIT_COMMIT"),
+        )
     }
-});
+};
 
 /// Renderer capabilities reported during the init handshake.
 ///
@@ -34,7 +37,7 @@ static RENDERER_IDENTIFIER: LazyLock<String> = LazyLock::new(|| {
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct RendererInitCapabilities {
     /// Human-readable stereo mode reported to the host.
-    pub stereo_rendering_mode: String,
+    pub stereo_rendering_mode: Cow<'static, str>,
     /// Maximum host texture dimension accepted by the renderer.
     pub max_texture_size: i32,
     /// Host texture formats accepted by the renderer.
@@ -110,7 +113,7 @@ pub(crate) fn build_renderer_init_result(
 ) -> RendererInitResult {
     RendererInitResult {
         actual_output_device: output_device,
-        renderer_identifier: Some(RENDERER_IDENTIFIER.clone()),
+        renderer_identifier: Some(RENDERER_IDENTIFIER.into()),
         main_window_handle_ptr: 0,
         stereo_rendering_mode: Some(capabilities.stereo_rendering_mode),
         max_texture_size: capabilities.max_texture_size,
@@ -165,7 +168,7 @@ mod tests {
         let result = build_renderer_init_result(
             Default::default(),
             RendererInitCapabilities {
-                stereo_rendering_mode: "None".to_string(),
+                stereo_rendering_mode: "None".into(),
                 max_texture_size: 4096,
                 supported_texture_formats: vec![TextureFormat::RGBA32],
             },

--- a/crates/renderide/src/runtime/ipc/effects/init_capabilities.rs
+++ b/crates/renderide/src/runtime/ipc/effects/init_capabilities.rs
@@ -73,7 +73,7 @@ fn renderer_init_capabilities(
         "None"
     };
     RendererInitCapabilities {
-        stereo_rendering_mode: stereo_rendering_mode.to_string(),
+        stereo_rendering_mode: stereo_rendering_mode.into(),
         max_texture_size: crate::gpu::RENDERER_MAX_TEXTURE_DIMENSION_2D as i32,
         supported_texture_formats: crate::assets::texture::supported_host_formats_for_init(),
     }


### PR DESCRIPTION
Also completely builds the version string at compile time instead of building it on first use at runtime.

FYI @Raidriar796 this affects the part of the code that you patched to add "(AUR)" to the version string, so you will need to redo that patch if this gets merged.