### PR TITLE
Make PBS Rim Transparent back-culled

### DIFF
--- a/crates/renderide/shaders/materials/pbsrimtransparent.wgsl
+++ b/crates/renderide/shaders/materials/pbsrimtransparent.wgsl
@@ -107,7 +107,7 @@ fn vs_main(
 #endif
 }
 
-//#pass forward_transparent
+//#pass forward_transparent_cull_back
 @fragment
 fn fs_main(
     @builtin(position) frag_pos: vec4<f32>,

--- a/crates/renderide/shaders/materials/pbsrimtransparentspecular.wgsl
+++ b/crates/renderide/shaders/materials/pbsrimtransparentspecular.wgsl
@@ -90,7 +90,7 @@ fn vs_main(
 #endif
 }
 
-//#pass forward_transparent
+//#pass forward_transparent_cull_back
 @fragment
 fn fs_main(
     @builtin(position) frag_pos: vec4<f32>,

--- a/crates/renderide/shaders/materials/pbsrimtransparentzwrite.wgsl
+++ b/crates/renderide/shaders/materials/pbsrimtransparentzwrite.wgsl
@@ -118,7 +118,7 @@ fn fs_depth_only(
     return rg::retain_globals_additive(vec4<f32>(touch, touch, touch, 0.0));
 }
 
-//#pass forward_transparent
+//#pass forward_transparent_cull_back
 @fragment
 fn fs_main(
     @builtin(position) frag_pos: vec4<f32>,

--- a/crates/renderide/shaders/materials/pbsrimtransparentzwritespecular.wgsl
+++ b/crates/renderide/shaders/materials/pbsrimtransparentzwritespecular.wgsl
@@ -110,7 +110,7 @@ fn fs_depth_only(
     return rg::retain_globals_additive(vec4<f32>(touch, touch, touch, 0.0));
 }
 
-//#pass forward_transparent
+//#pass forward_transparent_cull_back
 @fragment
 fn fs_main(
     @builtin(position) frag_pos: vec4<f32>,


### PR DESCRIPTION
The Unity renderer is culling back-faces on PBS Rim materials. This PR makes Renderide match this behavior.

Closes #457.

- [x] Verify `transparent`
- [x] Verify `transparent+specular`
- [x] Verify `transparent+zwrite`
- [x] Verify `transparent+zwrite+specular`