### PR TITLE
Make FurFX do shell offsets in model space

### DIFF
--- a/crates/renderide/shaders/modules/fur/common.wgsl
+++ b/crates/renderide/shaders/modules/fur/common.wgsl
@@ -51,7 +51,7 @@ fn fur_vertex_main(
     force_local: vec4<f32>,
 ) -> VertexOutput {
     let draw = pd::get_draw(instance_index);
-    let world_n = mv::world_normal(draw, n);
+    let world_n = mv::world_normal_unnormalized(draw, n);
     let world_t = mv::world_tangent(draw, t);
     let world_base = mv::world_position(draw, pos).xyz;
     let shell_offset = world_n * fur_length * fur_multiplier * hair_hardness;
@@ -64,7 +64,7 @@ fn fur_vertex_main(
     var out: VertexOutput;
     out.clip_pos = vp * vec4<f32>(world_p, 1.0);
     out.world_pos = world_p;
-    out.world_n = world_n;
+    out.world_n = normalize(world_n);
     out.world_t = world_t;
     out.main_uv = uvu::apply_st(uv0, main_st);
     out.noise_uv = uvu::apply_st(uv0, noise_st);

--- a/crates/renderide/shaders/modules/fur/common.wgsl
+++ b/crates/renderide/shaders/modules/fur/common.wgsl
@@ -51,14 +51,14 @@ fn fur_vertex_main(
     force_local: vec4<f32>,
 ) -> VertexOutput {
     let draw = pd::get_draw(instance_index);
-    let world_n = mv::world_normal_unnormalized(draw, n);
+    let world_n = mv::world_normal(draw, n);
     let world_t = mv::world_tangent(draw, t);
-    let world_base = mv::world_position(draw, pos).xyz;
-    let shell_offset = world_n * fur_length * fur_multiplier * hair_hardness;
+    let shell_offset = n * fur_length * fur_multiplier * hair_hardness;
+    let world_base = mv::world_position(draw, pos + shell_offset).xyz;
     let global_force = clamp(force_global.xyz, vec3<f32>(-1.0), vec3<f32>(1.0));
     let local_force = mv::model_vector(draw, clamp(force_local.xyz, vec3<f32>(-1.0), vec3<f32>(1.0)));
     let force_offset = (global_force + local_force) * fur_multiplier * fur_multiplier * fur_length;
-    let world_p = world_base + shell_offset + force_offset;
+    let world_p = world_base + force_offset;
     let vp = mv::select_view_proj(draw, view_idx);
 
     var out: VertexOutput;

--- a/crates/renderide/shaders/modules/mesh/vertex.wgsl
+++ b/crates/renderide/shaders/modules/mesh/vertex.wgsl
@@ -83,10 +83,6 @@ fn world_normal(draw: dt::PerDrawUniforms, n: vec4<f32>) -> vec3<f32> {
     return normalize(draw.normal_matrix * n.xyz);
 }
 
-fn world_normal_unnormalized(draw: dt::PerDrawUniforms, n: vec4<f32>) -> vec3<f32> {
-    return draw.normal_matrix * n.xyz;
-}
-
 fn model_vector(draw: dt::PerDrawUniforms, v: vec3<f32>) -> vec3<f32> {
     return (draw.model * vec4<f32>(v, 0.0)).xyz;
 }

--- a/crates/renderide/shaders/modules/mesh/vertex.wgsl
+++ b/crates/renderide/shaders/modules/mesh/vertex.wgsl
@@ -83,6 +83,10 @@ fn world_normal(draw: dt::PerDrawUniforms, n: vec4<f32>) -> vec3<f32> {
     return normalize(draw.normal_matrix * n.xyz);
 }
 
+fn world_normal_unnormalized(draw: dt::PerDrawUniforms, n: vec4<f32>) -> vec3<f32> {
+    return draw.normal_matrix * n.xyz;
+}
+
 fn model_vector(draw: dt::PerDrawUniforms, v: vec3<f32>) -> vec3<f32> {
     return (draw.model * vec4<f32>(v, 0.0)).xyz;
 }

--- a/crates/renderide/shaders/passes/compute/mesh_skinning.wgsl
+++ b/crates/renderide/shaders/passes/compute/mesh_skinning.wgsl
@@ -131,12 +131,20 @@ fn skin_main(@builtin(global_invocation_id) gid: vec3<u32>) {
 
     let nb = src_n[src_ni];
     let n_bind = vec3<f32>(nb.xyz);
-    var acc_n = vec3<f32>(0.0);
-    acc_n += w.x * (normal_matrix(bone_matrices[bx]) * n_bind);
-    acc_n += w.y * (normal_matrix(bone_matrices[by]) * n_bind);
-    acc_n += w.z * (normal_matrix(bone_matrices[bz]) * n_bind);
-    acc_n += w.w * (normal_matrix(bone_matrices[bw]) * n_bind);
+    // This approach preserves perpendicular normals:
+    // var acc_n = vec3<f32>(0.0);
+    // acc_n += w.x * (normal_matrix(bone_matrices[bx]) * n_bind);
+    // acc_n += w.y * (normal_matrix(bone_matrices[by]) * n_bind);
+    // acc_n += w.z * (normal_matrix(bone_matrices[bz]) * n_bind);
+    // acc_n += w.w * (normal_matrix(bone_matrices[bw]) * n_bind);
 
+    // To preserve Unity behavior, we need to do this instead:
+    var acc_n = vec4<f32>(0.0);
+    acc_n += w.x * (bone_matrices[bx] * nb);
+    acc_n += w.y * (bone_matrices[by] * nb);
+    acc_n += w.z * (bone_matrices[bz] * nb);
+    acc_n += w.w * (bone_matrices[bw] * nb);
+    
     let tangent_enabled = (skin_dispatch.flags & SKIN_TANGENTS) != 0u;
     var tb = vec4<f32>(0.0);
     var t_bind = vec3<f32>(0.0);
@@ -160,13 +168,17 @@ fn skin_main(@builtin(global_invocation_id) gid: vec3<u32>) {
 
     if (ws > 1e-6) {
         dst_pos[dst_pi] = vec4<f32>((acc / ws).xyz, p.w);
-        let n_fallback = safe_normalize(n_bind, vec3<f32>(0.0, 0.0, 1.0));
-        let nn = safe_normalize(acc_n / ws, n_fallback);
-        dst_n[dst_ni] = vec4<f32>(nn, nb.w);
+        // let n_fallback = safe_normalize(n_bind, vec3<f32>(0.0, 0.0, 1.0));
+        // let nn = safe_normalize(acc_n / ws, n_fallback);
+        // dst_n[dst_ni] = vec4<f32>(nn, nb.w);
+
+        // Don't normalize, this is important for some materials.
+        let norm = acc_n / ws;
+        dst_n[dst_ni] = norm;
         if (tangent_enabled) {
-            let tt = orthogonal_tangent(acc_t / ws, nn, t_bind);
+            let tt = orthogonal_tangent(acc_t / ws, norm.xyz, t_bind);
             let bb = safe_normalize(acc_b / ws, b_bind);
-            let sign = select(1.0, -1.0, dot(cross(nn, tt), bb) < 0.0);
+            let sign = select(1.0, -1.0, dot(cross(norm.xyz, tt), bb) < 0.0);
             dst_t[dst_ti] = vec4<f32>(tt, sign);
         }
     } else {


### PR DESCRIPTION
Might fix #472, matches Unity more.

Me: this PR
DoubleStyx: Renderide-main
Talii: Unity
<img width="781" height="843" alt="Image" src="https://github.com/user-attachments/assets/a2691311-570e-4ce6-892f-9d23dcf626ff" />