### PR TITLE
Support `-AttachRenderer`

### DIFF
--- a/crates/renderide-shared/src/ipc/connection.rs
+++ b/crates/renderide-shared/src/ipc/connection.rs
@@ -3,6 +3,7 @@
 //! Matches the managed host's argument convention (see `RenderingManager.GetConnectionParameters`).
 
 use std::env;
+use std::io::{Cursor, Read};
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use thiserror::Error;
@@ -45,18 +46,98 @@ pub fn try_claim_renderer_singleton() -> Result<(), InitError> {
 
 /// Parses `-QueueName` / `-QueueCapacity` from `std::env::args`, if present.
 ///
+/// If `-AttachRenderer` was passed, instead blocks and listens on UDP
+/// port 42512 for a message from the engine to provide these.
+///
 /// Returns [`None`] when arguments are missing or invalid so the process can run without IPC.
 pub fn get_connection_parameters() -> Option<ConnectionParams> {
     let args: Vec<String> = env::args().collect();
+
+    if args.iter().any(|arg| arg.ends_with("-AttachRenderer")) {
+        // Wait for a UDP packet with the connection parameters instead of parsing from command-line args.
+        logger::info!("Attempting to wait for Resonite to attach debug renderer.");
+        return get_connection_parameters_from_udp();
+    }
     parse_connection_args(&args)
 }
 
+/// Wait for connection parameters by listening on UDP port 42512.
+fn get_connection_parameters_from_udp() -> Option<ConnectionParams> {
+    // The data is encoded in the format of dotnet's BinaryWriter:
+    // QueueName: length-prefixed UTF-8 (7-bit encoded i32 length, then bytes).
+    // QueueCapacity: 8-byte little-endian i64.
+
+    // Get data
+    let socket = std::net::UdpSocket::bind("127.0.0.1:42512").ok()?;
+    logger::info!("Listening on UDP port 42512. Launch Resonite with -AttachRenderer");
+    let mut buf = [0u8; 1024];
+    let (len, _) = socket.recv_from(&mut buf).ok()?;
+    let mut cursor = Cursor::new(&buf[..len]);
+
+    // QueueName
+    let name_len = read_7bit_encoded_int(&mut cursor)?;
+    let queue_name = {
+        let mut name_buf = vec![0u8; name_len as usize];
+        cursor.read_exact(&mut name_buf).ok()?;
+        String::from_utf8(name_buf).ok()?
+    };
+
+    // QueueCapacity
+    let mut queue_capacity_buf: [u8; 8] = [0; 8];
+    cursor.read_exact(&mut queue_capacity_buf).ok()?;
+    let queue_capacity = i64::from_le_bytes(queue_capacity_buf);
+
+    // Validate
+    if queue_capacity <= 0 {
+        return None;
+    }
+
+    Some(ConnectionParams {
+        queue_name,
+        queue_capacity,
+    })
+}
+
+/// Read a 7-bit encoded int in the format used by dotnet BinaryWriter/BinaryReader for
+/// the length prefix on strings.
+fn read_7bit_encoded_int(cursor: &mut Cursor<&[u8]>) -> Option<i32> {
+    // Integer is encoded as a series of bytes, where the high bit
+    // indicates whether there is another bytes to come, and the remaining
+    // 7 bits are shifted into place from LSB to MSB. (Small numbers need fewer bytes this way.)
+
+    const FLAG_MORE: u8 = 0x80;
+    const MASK: u8 = !FLAG_MORE;
+
+    let mut out: u32 = 0;
+    let mut shift: u32 = 0;
+
+    let mut buf: [u8; 1] = [0];
+
+    // Keep grabbing bytes from the cursor until that fails or we've got our int.
+    loop {
+        cursor.read_exact(&mut buf).ok()?;
+
+        out |= ((buf[0] & MASK) as u32) << shift;
+
+        if buf[0] & FLAG_MORE == 0 {
+            break;
+        }
+
+        shift += 7;
+        if shift >= 32 {
+            return None;
+        }
+    }
+
+    Some(out as i32)
+}
+
 /// Scans `args` for the first complete `-QueueName` / `-QueueCapacity` pair (case-insensitive
-/// flag suffix). Returns [`None`] when either flag is missing, malformed, or duplicated before
-/// the pair completes; the renderer treats `None` as standalone mode.
-///
-/// This is the production parser; both [`get_connection_parameters`] and the unit tests drive it.
-fn parse_connection_args(args: &[String]) -> Option<ConnectionParams> {
+/// flag suffix).
+/// Requires QueueCapacity to be a positive integer.
+/// Returns [`None`] if either flag is missing, malformed, or duplicated before
+/// the pair completes.
+fn parse_connection_args(args: &[impl AsRef<str>]) -> Option<ConnectionParams> {
     if args.is_empty() {
         return None;
     }
@@ -72,18 +153,18 @@ fn parse_connection_args(args: &[String]) -> Option<ConnectionParams> {
             break;
         }
 
-        let arg_lower = arg.to_lowercase();
+        let arg_lower = arg.as_ref().to_lowercase();
         if arg_lower.ends_with("queuename") {
             if queue_name.is_some() {
                 return None;
             }
-            queue_name = Some(args[next_i].clone());
+            queue_name = Some(args[next_i].as_ref().to_owned());
             i = next_i;
         } else if arg_lower.ends_with("queuecapacity") {
             if queue_capacity.is_some_and(|c| c > 0) {
                 return None;
             }
-            queue_capacity = args[next_i].parse().ok().filter(|&c| c > 0);
+            queue_capacity = args[next_i].as_ref().parse().ok().filter(|&c| c > 0);
             i = next_i;
         }
 
@@ -124,11 +205,6 @@ pub fn publisher_queue_name(base: &str, channel: &str) -> String {
 mod tests {
     use super::*;
 
-    fn parse_args(args: &[&str]) -> Option<ConnectionParams> {
-        let owned: Vec<String> = args.iter().map(|s| (*s).to_string()).collect();
-        parse_connection_args(&owned)
-    }
-
     #[test]
     fn parses_queue_name_and_capacity_case_insensitive() {
         let cmd = [
@@ -139,7 +215,7 @@ mod tests {
             "8388608",
         ];
         assert_eq!(
-            parse_args(&cmd),
+            parse_connection_args(&cmd),
             Some(ConnectionParams {
                 queue_name: "TestSession".to_string(),
                 queue_capacity: 8_388_608,
@@ -157,7 +233,7 @@ mod tests {
             "LaterName",
         ];
         assert_eq!(
-            parse_args(&cmd),
+            parse_connection_args(&cmd),
             Some(ConnectionParams {
                 queue_name: "LaterName".into(),
                 queue_capacity: 4096,
@@ -175,7 +251,7 @@ mod tests {
             "2048",
         ];
         assert_eq!(
-            parse_args(&cmd),
+            parse_connection_args(&cmd),
             Some(ConnectionParams {
                 queue_name: "Prefixed".into(),
                 queue_capacity: 2048,
@@ -185,9 +261,9 @@ mod tests {
 
     #[test]
     fn parse_args_returns_none_when_flag_value_is_missing() {
-        assert_eq!(parse_args(&["renderide", "-QueueName"]), None);
+        assert_eq!(parse_connection_args(&["renderide", "-QueueName"]), None);
         assert_eq!(
-            parse_args(&["renderide", "-QueueName", "Name", "-QueueCapacity"]),
+            parse_connection_args(&["renderide", "-QueueName", "Name", "-QueueCapacity"]),
             None
         );
     }
@@ -205,7 +281,7 @@ mod tests {
         ];
 
         assert_eq!(
-            parse_args(&cmd),
+            parse_connection_args(&cmd),
             Some(ConnectionParams {
                 queue_name: "Recover".into(),
                 queue_capacity: 1024,
@@ -224,7 +300,7 @@ mod tests {
             "-QueueCapacity",
             "4096",
         ];
-        assert_eq!(parse_args(&cmd), None);
+        assert_eq!(parse_connection_args(&cmd), None);
     }
 
     #[test]
@@ -239,7 +315,7 @@ mod tests {
             "8192",
         ];
         assert_eq!(
-            parse_args(&cmd),
+            parse_connection_args(&cmd),
             Some(ConnectionParams {
                 queue_name: "S".into(),
                 queue_capacity: 4096,
@@ -250,22 +326,22 @@ mod tests {
     #[test]
     fn parse_args_rejects_non_numeric_or_non_positive_capacity() {
         assert_eq!(
-            parse_args(&["r", "-QueueName", "n", "-QueueCapacity", "not_a_number"]),
+            parse_connection_args(&["r", "-QueueName", "n", "-QueueCapacity", "not_a_number"]),
             None
         );
         assert_eq!(
-            parse_args(&["r", "-QueueName", "n", "-QueueCapacity", "0"]),
+            parse_connection_args(&["r", "-QueueName", "n", "-QueueCapacity", "0"]),
             None
         );
         assert_eq!(
-            parse_args(&["r", "-QueueName", "n", "-QueueCapacity", "-100"]),
+            parse_connection_args(&["r", "-QueueName", "n", "-QueueCapacity", "-100"]),
             None
         );
     }
 
     #[test]
     fn parse_args_returns_none_for_empty_argv() {
-        assert_eq!(parse_args(&[]), None);
+        assert_eq!(parse_connection_args(&Vec::<String>::new()), None);
     }
 
     #[test]

--- a/crates/renderide/src/app/bootstrap/logging.rs
+++ b/crates/renderide/src/app/bootstrap/logging.rs
@@ -89,6 +89,9 @@ fn sanitized_cli_mode() -> String {
     let ignore_config = args.iter().any(|arg| {
         arg.eq_ignore_ascii_case("--ignore-config") || arg.eq_ignore_ascii_case("-ignore-config")
     });
+    let attach_renderer = args
+        .iter()
+        .any(|arg| arg.to_ascii_lowercase().ends_with("-AttachRenderer"));
 
     let mut parts = Vec::new();
     if has_queue {
@@ -96,6 +99,9 @@ fn sanitized_cli_mode() -> String {
     }
     if has_queue_capacity {
         parts.push("queue-capacity");
+    }
+    if attach_renderer {
+        parts.push("attach-renderer");
     }
     if headless {
         parts.push("headless");


### PR DESCRIPTION
When Resonite is launched with `-AttachRenderer`, it sends the QueueName and QueueCapacity (normally passed as arguments to the renderer) over UDP to localhost port 42512.

This PR makes renderide-renderer listen for that data instead of parsing from args if `-AttachRenderer` is passed to it (I used the same flag as the Resonite side to avoid confusion).

I chose to implement this by blocking the thread in the same place where the CLI args would be parsed. Startup can't progress without this information anyway, so I don't think that is a problem. You're welcome to recommend/require a different approach, I have no particular attachment to this design.

Note: Renderide has to be listening before Resonite is launched, or it will not get the message.