### PR TITLE
Replicate ZTest conversion bug from Unity renderer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2682,6 +2682,7 @@ dependencies = [
  "naga_oil",
  "notify",
  "notify-debouncer-mini",
+ "num_enum",
  "openxr",
  "parking_lot",
  "pollster",

--- a/crates/renderide/Cargo.toml
+++ b/crates/renderide/Cargo.toml
@@ -113,6 +113,7 @@ tracy-client = { version = "0.18", optional = true, default-features = false, fe
 gstreamer = { version = "0.25", optional = true }
 gstreamer-app = { version = "0.25", optional = true }
 directories = "6.0"
+num_enum = "0.7.6"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 wgpu = { version = "29.0", features = ["vulkan-portability"] }

--- a/crates/renderide/shaders/materials/pbslerp.wgsl
+++ b/crates/renderide/shaders/materials/pbslerp.wgsl
@@ -151,7 +151,7 @@ fn vs_main(
 #endif
 }
 
-//#pass type=forward
+//#pass type=forward ztest=main
 @fragment
 fn fs_main(
     @builtin(position) frag_pos: vec4<f32>,

--- a/crates/renderide/shaders/materials/pbslerpspecular.wgsl
+++ b/crates/renderide/shaders/materials/pbslerpspecular.wgsl
@@ -147,7 +147,7 @@ fn vs_main(
 #endif
 }
 
-//#pass type=forward
+//#pass type=forward ztest=main
 @fragment
 fn fs_main(
     @builtin(position) frag_pos: vec4<f32>,

--- a/crates/renderide/src/materials/material_passes/wire_tables.rs
+++ b/crates/renderide/src/materials/material_passes/wire_tables.rs
@@ -22,6 +22,57 @@ pub(crate) fn unity_compare_function(value: u8) -> wgpu::CompareFunction {
     }
 }
 
+/// Helper enum for converting the FrooxEngine forward-Z ZTest enum into the WGPU equivalent.
+#[derive(num_enum::TryFromPrimitive)]
+#[repr(u8)]
+enum FrooxEngineZTest {
+    Less,
+    Greater,
+    LessOrEqual,
+    GreaterOrEqual,
+    Equal,
+    NotEqual,
+    Always,
+    /// Does not exist on FrooxEngine side, needed for wgpu parity.
+    Never = 255,
+}
+
+impl FrooxEngineZTest {
+    /// Replicates Resonite bug behavior:
+    /// https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/1618
+    /// TODO: Fix this in FrooxEngine
+    pub fn map_1618(self) -> Self {
+        use FrooxEngineZTest::*;
+        match self {
+            Less => Always,
+            Equal => LessOrEqual,
+            LessOrEqual => Less,
+            Greater => Never,
+            NotEqual => Greater,
+            GreaterOrEqual => Equal,
+            Always => NotEqual,
+            Never => Never,
+        }
+    }
+}
+
+impl Into<wgpu::CompareFunction> for FrooxEngineZTest {
+    /// Converts from the forward-Z ZTest type of FrooxEngine into
+    /// the revers-Z [`wgpu::CompareFunction`].
+    fn into(self) -> wgpu::CompareFunction {
+        match self {
+            Self::Less => wgpu::CompareFunction::Greater,
+            Self::Greater => wgpu::CompareFunction::Less,
+            Self::LessOrEqual => wgpu::CompareFunction::GreaterEqual,
+            Self::GreaterOrEqual => wgpu::CompareFunction::LessEqual,
+            Self::Equal => wgpu::CompareFunction::Equal,
+            Self::NotEqual => wgpu::CompareFunction::NotEqual,
+            Self::Always => wgpu::CompareFunction::Always,
+            Self::Never => wgpu::CompareFunction::Never,
+        }
+    }
+}
+
 /// Maps a FrooxEngine `ZTest` enum value carried on the host `_ZTest` property to the reverse-Z
 /// equivalent `wgpu::CompareFunction`.
 ///
@@ -33,16 +84,9 @@ pub(crate) fn unity_compare_function(value: u8) -> wgpu::CompareFunction {
 /// Depth-test comparisons invert under reverse-Z (near fragments have greater depth), so e.g.
 /// `ZTest.LessOrEqual` -- the usual opaque-pass default -- becomes `wgpu::CompareFunction::GreaterEqual`.
 pub(crate) fn froox_ztest_depth_compare_function(value: u8) -> Option<wgpu::CompareFunction> {
-    match value {
-        0 => Some(wgpu::CompareFunction::Greater),
-        1 => Some(wgpu::CompareFunction::Less),
-        2 => Some(wgpu::CompareFunction::GreaterEqual),
-        3 => Some(wgpu::CompareFunction::LessEqual),
-        4 => Some(wgpu::CompareFunction::Equal),
-        5 => Some(wgpu::CompareFunction::NotEqual),
-        ZTEST_ALWAYS => Some(wgpu::CompareFunction::Always),
-        _ => None,
-    }
+    FrooxEngineZTest::try_from(value)
+        .ok()
+        .map(|fe_ztest| fe_ztest.map_1618().into())
 }
 
 /// Maps a Unity `CompareFunction` `_ZTest` value to the reverse-Z equivalent


### PR DESCRIPTION
This PR introduces the dependency [`num_enum`](https://crates.io/crates/num_enum) for deriving conversions from an enum with the `#[repr(..)]` attribute and much more. It is a very common dependency with 200,700,071 downloads all time and ~57k today.

Closes #490.

Not complete yet, as there are some issues remaining:
<img width="525" height="429" alt="image" src="https://github.com/user-attachments/assets/5582851a-3404-431d-a691-cc15b57ca8f1" />
