### PR TITLE
Tweak Post Processing

### DIFF
--- a/crates/renderide/src/config/types/post_processing/auto_exposure.rs
+++ b/crates/renderide/src/config/types/post_processing/auto_exposure.rs
@@ -97,7 +97,7 @@ impl AutoExposureSettings {
 impl Default for AutoExposureSettings {
     fn default() -> Self {
         Self {
-            enabled: true,
+            enabled: false,
             min_ev: -16.0,
             max_ev: 16.0,
             low_percent: 0.25,

--- a/crates/renderide/src/config/types/post_processing/auto_exposure.rs
+++ b/crates/renderide/src/config/types/post_processing/auto_exposure.rs
@@ -98,8 +98,8 @@ impl Default for AutoExposureSettings {
     fn default() -> Self {
         Self {
             enabled: false,
-            min_ev: -16.0,
-            max_ev: 16.0,
+            min_ev: -8.0,
+            max_ev: 8.0,
             low_percent: 0.25,
             high_percent: 0.75,
             speed_brighten: 3.0,

--- a/crates/renderide/src/config/types/post_processing/bloom.rs
+++ b/crates/renderide/src/config/types/post_processing/bloom.rs
@@ -73,13 +73,13 @@ impl Default for BloomSettings {
     fn default() -> Self {
         Self {
             enabled: true,
-            intensity: 0.667,
+            intensity: 0.5,
             low_frequency_boost: 0.0,
             low_frequency_boost_curvature: 1.0,
             high_pass_frequency: 1.0,
             prefilter_threshold: 1.0,
             prefilter_threshold_softness: 0.5,
-            composite_mode: BloomCompositeMode::EnergyConserving,
+            composite_mode: BloomCompositeMode::Additive,
             max_mip_dimension: 512,
         }
     }

--- a/crates/renderide/src/config/types/post_processing/bloom.rs
+++ b/crates/renderide/src/config/types/post_processing/bloom.rs
@@ -74,9 +74,9 @@ impl Default for BloomSettings {
         Self {
             enabled: true,
             intensity: 0.5,
-            low_frequency_boost: 0.3,
+            low_frequency_boost: 0.5,
             low_frequency_boost_curvature: 1.0,
-            high_pass_frequency: 0.6,
+            high_pass_frequency: 0.5,
             prefilter_threshold: 1.0,
             prefilter_threshold_softness: 0.5,
             composite_mode: BloomCompositeMode::EnergyConserving,

--- a/crates/renderide/src/config/types/post_processing/bloom.rs
+++ b/crates/renderide/src/config/types/post_processing/bloom.rs
@@ -74,12 +74,12 @@ impl Default for BloomSettings {
         Self {
             enabled: true,
             intensity: 0.5,
-            low_frequency_boost: 0.0,
+            low_frequency_boost: 0.3,
             low_frequency_boost_curvature: 1.0,
-            high_pass_frequency: 1.0,
+            high_pass_frequency: 0.6,
             prefilter_threshold: 1.0,
             prefilter_threshold_softness: 0.5,
-            composite_mode: BloomCompositeMode::Additive,
+            composite_mode: BloomCompositeMode::EnergyConserving,
             max_mip_dimension: 512,
         }
     }

--- a/crates/renderide/src/config/types/post_processing/gtao.rs
+++ b/crates/renderide/src/config/types/post_processing/gtao.rs
@@ -70,7 +70,7 @@ impl Default for GtaoSettings {
             quality_level: 3,
             radius_meters: 1.0,
             radius_multiplier: 1.457,
-            intensity: 1.0,
+            intensity: 0.33,
             max_pixel_radius: 256.0,
             step_count: 16,
             falloff_range: 1.0,

--- a/crates/renderide/src/config/types/post_processing/gtao.rs
+++ b/crates/renderide/src/config/types/post_processing/gtao.rs
@@ -70,7 +70,7 @@ impl Default for GtaoSettings {
             quality_level: 3,
             radius_meters: 1.0,
             radius_multiplier: 1.457,
-            intensity: 0.33,
+            intensity: 0.5,
             max_pixel_radius: 256.0,
             step_count: 16,
             falloff_range: 1.0,

--- a/crates/renderide/src/config/types/post_processing/motion_blur.rs
+++ b/crates/renderide/src/config/types/post_processing/motion_blur.rs
@@ -63,7 +63,7 @@ impl Default for MotionBlurSettings {
         Self {
             enabled: true,
             allow_vr: false,
-            shutter_angle: 1.0,
+            shutter_angle: 0.5,
             sample_count: 16,
             max_velocity_pixels: 512.0,
         }


### PR DESCRIPTION
This contains small tweaks meant to match the look of Resonite's default post processing. This will help with visual comparisons as well as having a less jarring introduction to Renderide.

This is far from exact, but it matches significantly more than it did before.