### PR TITLE
Fix Refract material and very large render queue values

### DIFF
--- a/crates/renderide/shaders/modules/frame/scene_depth_sample.wgsl
+++ b/crates/renderide/shaders/modules/frame/scene_depth_sample.wgsl
@@ -32,13 +32,16 @@ fn linear_depth_from_raw(raw_depth: f32, view_layer: u32) -> f32 {
     return (rg::frame.near_clip * rg::frame.far_clip) / denom;
 }
 
-fn scene_linear_depth_at_xy(xy: vec2<i32>, view_layer: u32) -> f32 {
+fn raw_depth_at_xy(xy: vec2<i32>, view_layer: u32) -> f32 {
 #ifdef MULTIVIEW
-    let raw_depth = textureLoad(rg::scene_depth_array, xy, i32(rg::view_index_from_layer(view_layer)), 0);
+    return textureLoad(rg::scene_depth_array, xy, i32(rg::view_index_from_layer(view_layer)), 0);
 #else
-    let raw_depth = textureLoad(rg::scene_depth, xy, 0);
+    return textureLoad(rg::scene_depth, xy, 0);
 #endif
-    return linear_depth_from_raw(raw_depth, view_layer);
+}
+
+fn scene_linear_depth_at_xy(xy: vec2<i32>, view_layer: u32) -> f32 {
+    return linear_depth_from_raw(raw_depth_at_xy(xy, view_layer), view_layer);
 }
 
 fn scene_linear_depth(frag_pos: vec4<f32>, view_layer: u32) -> f32 {

--- a/crates/renderide/shaders/modules/post/filter_refraction.wgsl
+++ b/crates/renderide/shaders/modules/post/filter_refraction.wgsl
@@ -76,11 +76,16 @@ fn guarded_refracted_screen_uv(
         normal_map,
         normal_sampler,
     ) * fade * fm::screen_vignette(screen_uv);
-    let grab_uv = screen_uv - offset;
-    let sampled_depth = sds::scene_linear_depth_at_uv(grab_uv, view_layer);
+    let grab_uv = screen_uv + offset;
+
+    // Linearizing the fragment depth twice, and the scene depth not at all.
+    // This is what Unity does, and somehow it works!?
+    let sampled_xy = sds::scene_depth_xy_from_uv(grab_uv);
+    let sampled_depth = sds::raw_depth_at_xy(sampled_xy, view_layer);
     let fragment_depth = sds::fragment_linear_depth(world_pos, view_layer);
-    if (sampled_depth > fragment_depth + depth_bias) {
+    if (sampled_depth > sds::linear_depth_from_raw(fragment_depth, view_layer) + depth_bias) {
         return screen_uv;
     }
+
     return grab_uv;
 }

--- a/crates/renderide/src/materials/host_data/update_batch/dispatch.rs
+++ b/crates/renderide/src/materials/host_data/update_batch/dispatch.rs
@@ -180,7 +180,7 @@ fn apply_structural_opcode(
                     store,
                     target,
                     render_queue_pid,
-                    MaterialPropertyValue::Float(property_id as f32),
+                    MaterialPropertyValue::Float(unity_render_queue_conversion(property_id) as f32),
                 );
             }
             !is_property_block
@@ -198,6 +198,25 @@ fn apply_structural_opcode(
         }
         _ => false,
     }
+}
+
+/// Applies the render queue mechanism that Unity uses for very large values.
+/// Queues behave exactly as expected until reaching 2^15.
+/// After that point, they seem to behave like slightly non opaque geometry (2501),
+/// until reaching 2^16+2501, at which point they start behaving
+/// as if they wrapped around to 2501.
+/// Then the cycle continues: as expected of (x-2^16)
+/// until they reach 2^16+2^15, at which point they return to 2000,
+/// and so on... Repeating every 2^16. Tested manually up to 163840 (2^17 + 2^15).
+fn unity_render_queue_conversion(queue: i32) -> i32 {
+    if queue < 0x8000 {
+        return queue;
+    }
+    let truncated = queue & 0xFFFF;
+    if truncated < 2501 || truncated >= 0x8000 {
+        return 2501;
+    }
+    truncated
 }
 
 /// Applies one material/property-block opcode after [`MaterialBatchTarget`] is active (excludes target switching).

--- a/crates/renderide/src/materials/host_data/update_batch/dispatch.rs
+++ b/crates/renderide/src/materials/host_data/update_batch/dispatch.rs
@@ -180,7 +180,7 @@ fn apply_structural_opcode(
                     store,
                     target,
                     render_queue_pid,
-                    MaterialPropertyValue::Float(unity_render_queue_conversion(property_id) as f32),
+                    MaterialPropertyValue::Float(property_id as f32),
                 );
             }
             !is_property_block
@@ -198,25 +198,6 @@ fn apply_structural_opcode(
         }
         _ => false,
     }
-}
-
-/// Applies the render queue mechanism that Unity uses for very large values.
-/// Queues behave exactly as expected until reaching 2^15.
-/// After that point, they seem to behave like slightly non opaque geometry (2501),
-/// until reaching 2^16+2501, at which point they start behaving
-/// as if they wrapped around to 2501.
-/// Then the cycle continues: as expected of (x-2^16)
-/// until they reach 2^16+2^15, at which point they return to 2000,
-/// and so on... Repeating every 2^16. Tested manually up to 163840 (2^17 + 2^15).
-fn unity_render_queue_conversion(queue: i32) -> i32 {
-    if queue < 0x8000 {
-        return queue;
-    }
-    let truncated = queue & 0xFFFF;
-    if truncated < 2501 || truncated >= 0x8000 {
-        return 2501;
-    }
-    truncated
 }
 
 /// Applies one material/property-block opcode after [`MaterialBatchTarget`] is active (excludes target switching).

--- a/crates/renderide/src/materials/render_queue.rs
+++ b/crates/renderide/src/materials/render_queue.rs
@@ -65,7 +65,26 @@ fn sanitized_render_queue_override(raw: f32) -> Option<i32> {
         return None;
     }
     let queue = raw.round() as i32;
-    (queue >= 0).then_some(queue)
+    (queue >= 0).then(|| unity_render_queue_conversion(queue))
+}
+
+/// Applies the render queue mechanism that Unity uses for very large values.
+/// Queues behave exactly as expected until reaching 2^15.
+/// After that point, they seem to behave like slightly non opaque geometry (2501),
+/// until reaching 2^16+2501, at which point they start behaving
+/// as if they wrapped around to 2501.
+/// Then the cycle continues: as expected of (x-2^16)
+/// until they reach 2^16+2^15, at which point they return to 2000,
+/// and so on... Repeating every 2^16. Tested manually up to 163840 (2^17 + 2^15).
+fn unity_render_queue_conversion(queue: i32) -> i32 {
+    if queue < 0x8000 {
+        return queue;
+    }
+    let truncated = queue & 0xFFFF;
+    if (UNITY_TRANSPARENT_RENDER_QUEUE_MIN..0x8000).contains(&truncated) {
+        return truncated;
+    }
+    UNITY_TRANSPARENT_RENDER_QUEUE_MIN
 }
 
 #[cfg(test)]
@@ -115,6 +134,42 @@ mod tests {
                 UNITY_RENDER_QUEUE_TRANSPARENT,
             ),
             UNITY_RENDER_QUEUE_TRANSPARENT
+        );
+    }
+
+    #[test]
+    fn render_queue_pins_value_between_2_15_and_2_16() {
+        let registry = PropertyIdRegistry::new();
+        let ids = MaterialPipelinePropertyIds::new(&registry);
+        let mut material = HashMap::new();
+        material.insert(ids.render_queue[0], MaterialPropertyValue::Float(42_000.0));
+
+        assert_eq!(
+            material_render_queue_from_maps(
+                Some(&material),
+                None,
+                &ids,
+                UNITY_RENDER_QUEUE_GEOMETRY,
+            ),
+            UNITY_TRANSPARENT_RENDER_QUEUE_MIN
+        );
+    }
+
+    #[test]
+    fn render_queue_wraps_around_after_2_16() {
+        let registry = PropertyIdRegistry::new();
+        let ids = MaterialPipelinePropertyIds::new(&registry);
+        let mut material = HashMap::new();
+        material.insert(ids.render_queue[0], MaterialPropertyValue::Float(69_536.0));
+
+        assert_eq!(
+            material_render_queue_from_maps(
+                Some(&material),
+                None,
+                &ids,
+                UNITY_RENDER_QUEUE_GEOMETRY,
+            ),
+            UNITY_RENDER_QUEUE_OVERLAY
         );
     }
 


### PR DESCRIPTION
Fixes #425 by tweaking the maths of the refract shader to fit the exact behavior of the reference Unity shader (these maths are possibly incorrect, but legacy and expected).

Also fixes a parity issue with Unity regarding the processing of render queues.
Unity does some weird stuff once you go above 32768, let me tell you!
Well, I suppose it’s easier if you just read the new function and its doc comment.