### PR TITLE
[XSToon] Use same blend mode for outlines as for main material

### DIFF
--- a/crates/renderide/shaders/materials/xstoon2.0-cutouta2c-outlined.wgsl
+++ b/crates/renderide/shaders/materials/xstoon2.0-cutouta2c-outlined.wgsl
@@ -86,7 +86,7 @@ fn vs_outline(
 #endif
 }
 
-//#pass type=forward name=outline blend=off cull=front vs=vs_outline a2c=true
+//#pass type=forward name=outline cull=front vs=vs_outline a2c=true
 @fragment
 fn fs_outline(
     @builtin(position) frag_pos: vec4<f32>,

--- a/crates/renderide/shaders/materials/xstoon2.0-dithered-outlined.wgsl
+++ b/crates/renderide/shaders/materials/xstoon2.0-dithered-outlined.wgsl
@@ -86,7 +86,7 @@ fn vs_outline(
 #endif
 }
 
-//#pass type=forward name=outline blend=off cull=front vs=vs_outline
+//#pass type=forward name=outline cull=front vs=vs_outline
 @fragment
 fn fs_outline(
     @builtin(position) frag_pos: vec4<f32>,

--- a/crates/renderide/shaders/materials/xstoon2.0-outlined.wgsl
+++ b/crates/renderide/shaders/materials/xstoon2.0-outlined.wgsl
@@ -89,7 +89,7 @@ fn vs_outline(
 #endif
 }
 
-//#pass type=forward name=outline blend=off cull=front vs=vs_outline
+//#pass type=forward name=outline cull=front vs=vs_outline
 @fragment
 fn fs_outline(
     @builtin(position) frag_pos: vec4<f32>,

--- a/crates/renderide/shaders/materials/xstoon2.0_outlined.wgsl
+++ b/crates/renderide/shaders/materials/xstoon2.0_outlined.wgsl
@@ -90,7 +90,7 @@ fn vs_outline(
 #endif
 }
 
-//#pass type=forward name=outline blend=off cull=front vs=vs_outline
+//#pass type=forward name=outline cull=front vs=vs_outline
 @fragment
 fn fs_outline(
     @builtin(position) frag_pos: vec4<f32>,


### PR DESCRIPTION
Fixes #442 

The blend mode for outlines was simply forced off, whereas in Unity they visibly use the same blend mode as the main pass.