### PR TITLE
Use different transparent threshold depending on blend mode

### DIFF
--- a/crates/renderide/src/materials.rs
+++ b/crates/renderide/src/materials.rs
@@ -126,11 +126,12 @@ pub(crate) use pipeline_build_error::PipelineBuildError;
 pub(crate) use pipeline_kind::RasterPipelineKind;
 /// Pipeline family descriptors, per-property GPU layout, and raster kind flags.
 pub(crate) use raster_pipeline::MaterialPipelineDesc;
-pub(crate) use render_queue::{UNITY_RENDER_QUEUE_ALPHA_TEST, render_queue_is_transparent};
-#[cfg(test)]
 pub(crate) use render_queue::{
-    UNITY_RENDER_QUEUE_GEOMETRY, UNITY_RENDER_QUEUE_OVERLAY, UNITY_RENDER_QUEUE_TRANSPARENT,
+    UNITY_RENDER_QUEUE_ALPHA_TEST, UNITY_RENDER_QUEUE_TRANSPARENT,
+    UNITY_TRANSPARENT_RENDER_QUEUE_MIN,
 };
+#[cfg(test)]
+pub(crate) use render_queue::{UNITY_RENDER_QUEUE_GEOMETRY, UNITY_RENDER_QUEUE_OVERLAY};
 pub(crate) use render_queue::{
     fallback_render_queue_for_material, material_render_queue_from_maps,
 };

--- a/crates/renderide/src/materials/pipeline_kind.rs
+++ b/crates/renderide/src/materials/pipeline_kind.rs
@@ -3,10 +3,11 @@
 use std::sync::Arc;
 
 /// Raster pipeline identity for mesh draws: one embedded WGSL target per shader, or the null fallback.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum RasterPipelineKind {
     /// Composed WGSL stem under `shaders/target/` (for example `ui_textunlit_default`), built at compile time.
     EmbeddedStem(Arc<str>),
     /// Object-space black/grey checkerboard fallback when the host shader has no embedded target.
+    #[default]
     Null,
 }

--- a/crates/renderide/src/materials/render_queue.rs
+++ b/crates/renderide/src/materials/render_queue.rs
@@ -7,9 +7,6 @@ use super::material_passes::{MaterialPipelinePropertyIds, PropertyMapRef};
 pub const UNITY_RENDER_QUEUE_GEOMETRY: i32 = 2000;
 /// Unity `AlphaTest` render queue.
 pub const UNITY_RENDER_QUEUE_ALPHA_TEST: i32 = 2450;
-/// Highest Unity queue value still sorted as opaque by the Built-in Render Pipeline.
-#[cfg(test)]
-pub const UNITY_OPAQUE_RENDER_QUEUE_MAX: i32 = 2500;
 /// First Unity queue value sorted as transparent by the Built-in Render Pipeline.
 pub const UNITY_TRANSPARENT_RENDER_QUEUE_MIN: i32 = 2501;
 /// Unity `Transparent` render queue and the fallback queue for unqueued alpha-blended materials.
@@ -17,12 +14,6 @@ pub const UNITY_RENDER_QUEUE_TRANSPARENT: i32 = 3000;
 /// Unity `Overlay` render queue.
 #[cfg(test)]
 pub const UNITY_RENDER_QUEUE_OVERLAY: i32 = 4000;
-
-/// Returns whether a Unity render queue uses transparent-style sorting.
-#[inline]
-pub fn render_queue_is_transparent(render_queue: i32) -> bool {
-    render_queue >= UNITY_TRANSPARENT_RENDER_QUEUE_MIN
-}
 
 /// Returns the compatibility fallback queue when the host did not send a material queue.
 #[inline]
@@ -92,14 +83,6 @@ mod tests {
     use super::*;
     use crate::materials::host_data::{MaterialPropertyValue, PropertyIdRegistry};
     use hashbrown::HashMap;
-
-    #[test]
-    fn transparent_sorting_starts_after_opaque_cutoff() {
-        assert!(!render_queue_is_transparent(UNITY_OPAQUE_RENDER_QUEUE_MAX));
-        assert!(render_queue_is_transparent(
-            UNITY_TRANSPARENT_RENDER_QUEUE_MIN
-        ));
-    }
 
     #[test]
     fn material_render_queue_uses_material_override() {

--- a/crates/renderide/src/world_mesh/draw_prep/arrange.rs
+++ b/crates/renderide/src/world_mesh/draw_prep/arrange.rs
@@ -220,9 +220,7 @@ fn cmp_nontransparent_bin_keys(a: &NonTransparentBinKey, b: &NonTransparentBinKe
 
 #[cfg(test)]
 mod tests {
-    use crate::materials::{
-        UNITY_RENDER_QUEUE_ALPHA_TEST, UNITY_RENDER_QUEUE_TRANSPARENT, render_queue_is_transparent,
-    };
+    use crate::materials::{UNITY_RENDER_QUEUE_ALPHA_TEST, UNITY_RENDER_QUEUE_TRANSPARENT};
     use crate::world_mesh::draw_prep::pack_sort_prefix;
     use crate::world_mesh::materials::compute_batch_key_hash;
     use crate::world_mesh::test_fixtures::{DummyDrawItemSpec, dummy_world_mesh_draw_item};
@@ -252,6 +250,7 @@ mod tests {
         item.sort_prefix = pack_sort_prefix(
             item.is_overlay,
             item.batch_key.render_queue,
+            item.batch_key.is_transparent(),
             item._opaque_depth_bucket,
             item.batch_key_hash,
         );
@@ -277,7 +276,7 @@ mod tests {
                     item.collect_order,
                     item.mesh_asset_id,
                     item.batch_key.material_asset_id,
-                    render_queue_is_transparent(item.batch_key.render_queue),
+                    item.batch_key.is_transparent(),
                     item.batch_key.embedded_requires_intersection_pass,
                 )
             })
@@ -337,7 +336,7 @@ mod tests {
             UNITY_RENDER_QUEUE_ALPHA_TEST
         );
         assert!(draws[1].batch_key.embedded_requires_intersection_pass);
-        assert!(render_queue_is_transparent(draws[2].batch_key.render_queue));
+        assert!(draws[2].batch_key.is_transparent());
     }
 
     #[test]

--- a/crates/renderide/src/world_mesh/draw_prep/collect/candidate.rs
+++ b/crates/renderide/src/world_mesh/draw_prep/collect/candidate.rs
@@ -3,10 +3,7 @@
 use glam::{Mat4, Vec3};
 
 use crate::materials::host_data::MaterialPropertyLookupIds;
-use crate::materials::{
-    MaterialDepthCompareOverride, RasterFrontFace, RasterPrimitiveTopology,
-    render_queue_is_transparent,
-};
+use crate::materials::{MaterialDepthCompareOverride, RasterFrontFace, RasterPrimitiveTopology};
 use crate::reflection_probes::specular::ReflectionProbeDrawSelection;
 use crate::scene::{MeshRendererInstanceId, RenderSpaceId};
 use crate::world_mesh::culling::overlay_rect_clip_visible;
@@ -102,7 +99,7 @@ pub(super) fn evaluate_draw_candidate(
     let batch_key = apply_overlay_layer_depth_policy(batch_key, candidate.is_overlay);
     let blendshape_deformed = candidate.blendshape_deformed
         || (candidate.tangent_blendshape_deform_active && batch_key.embedded_needs_tangent);
-    let camera_distance_sq = if render_queue_is_transparent(batch_key.render_queue) {
+    let camera_distance_sq = if batch_key.is_transparent() {
         transparent_sort_distance_sq(
             ctx.view_origin_world,
             candidate.world_aabb,
@@ -123,6 +120,7 @@ pub(super) fn evaluate_draw_candidate(
     let sort_prefix = crate::world_mesh::draw_prep::sort::pack_sort_prefix(
         candidate.is_overlay,
         batch_key.render_queue,
+        batch_key.is_transparent(),
         opaque_depth_bucket,
         batch_key_hash,
     );

--- a/crates/renderide/src/world_mesh/draw_prep/sort.rs
+++ b/crates/renderide/src/world_mesh/draw_prep/sort.rs
@@ -4,8 +4,6 @@ use std::cmp::Ordering;
 
 use rayon::slice::ParallelSliceMut;
 
-use crate::materials::render_queue_is_transparent;
-
 use super::item::WorldMeshDrawItem;
 
 /// Draws assigned to one secondary structural resort worker chunk.
@@ -63,12 +61,12 @@ pub(super) fn opaque_depth_bucket(distance_sq: f32) -> u16 {
 pub fn pack_sort_prefix(
     is_overlay: bool,
     render_queue: i32,
+    is_transparent: bool,
     opaque_depth_bucket: u16,
     batch_key_hash: u64,
 ) -> u64 {
     let overlay_bit = u64::from(is_overlay);
     let render_queue_clamped = render_queue.clamp(0, SORT_PREFIX_RENDER_QUEUE_MAX) as u64;
-    let is_transparent = render_queue_is_transparent(render_queue);
     let transparent_bit = u64::from(is_transparent);
     let (depth_bits, hash_bits) = if is_transparent {
         (0u64, 0u64)
@@ -174,7 +172,7 @@ fn resort_intra_prefix_runs(items: &mut [WorldMeshDrawItem], allow_parallel: boo
             end += 1;
         }
         if end - start > 1 {
-            let is_transparent = render_queue_is_transparent(items[start].batch_key.render_queue);
+            let is_transparent = items[start].batch_key.is_transparent();
             if is_transparent {
                 sort_intra_prefix_run(
                     &mut items[start..end],

--- a/crates/renderide/src/world_mesh/draw_prep/sort/tests.rs
+++ b/crates/renderide/src/world_mesh/draw_prep/sort/tests.rs
@@ -2,7 +2,6 @@ use std::cmp::Ordering;
 
 use crate::materials::{
     UNITY_RENDER_QUEUE_ALPHA_TEST, UNITY_RENDER_QUEUE_OVERLAY, UNITY_RENDER_QUEUE_TRANSPARENT,
-    render_queue_is_transparent,
 };
 use crate::world_mesh::TransparentMaterialClass;
 use crate::world_mesh::draw_prep::item::WorldMeshDrawItem;
@@ -20,8 +19,8 @@ use super::{
 /// fix-up.
 fn cmp_world_mesh_draw_items(a: &WorldMeshDrawItem, b: &WorldMeshDrawItem) -> Ordering {
     a.sort_prefix.cmp(&b.sort_prefix).then_with(|| {
-        let a_transparent = render_queue_is_transparent(a.batch_key.render_queue);
-        let b_transparent = render_queue_is_transparent(b.batch_key.render_queue);
+        let a_transparent = a.batch_key.is_transparent();
+        let b_transparent = b.batch_key.is_transparent();
         match (a_transparent, b_transparent) {
             (false, false) => a
                 .batch_key_hash
@@ -44,20 +43,17 @@ fn cmp_world_mesh_draw_items_without_depth_bucket(
 ) -> Ordering {
     a.is_overlay
         .cmp(&b.is_overlay)
-        .then(a.batch_key.render_queue.cmp(&b.batch_key.render_queue))
         .then(
-            render_queue_is_transparent(a.batch_key.render_queue)
-                .cmp(&render_queue_is_transparent(b.batch_key.render_queue)),
+            a.batch_key
+                .is_transparent()
+                .cmp(&b.batch_key.is_transparent()),
         )
-        .then_with(|| {
-            match (
-                render_queue_is_transparent(a.batch_key.render_queue),
-                render_queue_is_transparent(b.batch_key.render_queue),
-            ) {
-                (false, false) => a
-                    .batch_key
-                    .cmp(&b.batch_key)
-                    .then(b.sorting_order.cmp(&a.sorting_order))
+        .then(a.batch_key.render_queue.cmp(&b.batch_key.render_queue))
+        .then_with(
+            || match (a.batch_key.is_transparent(), b.batch_key.is_transparent()) {
+                (false, false) => b
+                    .sorting_order
+                    .cmp(&a.sorting_order)
                     .then(a.mesh_asset_id.cmp(&b.mesh_asset_id))
                     .then(a.node_id.cmp(&b.node_id))
                     .then(a.slot_index.cmp(&b.slot_index)),
@@ -67,8 +63,8 @@ fn cmp_world_mesh_draw_items_without_depth_bucket(
                     .then_with(|| b.camera_distance_sq.total_cmp(&a.camera_distance_sq))
                     .then(a.collect_order.cmp(&b.collect_order)),
                 _ => Ordering::Equal,
-            }
-        })
+            },
+        )
 }
 
 /// Sets `camera_distance_sq` and refreshes the precomputed `opaque_depth_bucket` and
@@ -80,6 +76,7 @@ fn set_camera_distance(item: &mut WorldMeshDrawItem, distance_sq: f32) {
     item.sort_prefix = pack_sort_prefix(
         item.is_overlay,
         item.batch_key.render_queue,
+        item.batch_key.is_transparent(),
         item._opaque_depth_bucket,
         item.batch_key_hash,
     );
@@ -91,6 +88,7 @@ fn set_render_queue(item: &mut WorldMeshDrawItem, render_queue: i32) {
     item.sort_prefix = pack_sort_prefix(
         item.is_overlay,
         item.batch_key.render_queue,
+        item.batch_key.is_transparent(),
         item._opaque_depth_bucket,
         item.batch_key_hash,
     );
@@ -103,6 +101,7 @@ fn set_transparent_class(item: &mut WorldMeshDrawItem, class: TransparentMateria
     item.sort_prefix = pack_sort_prefix(
         item.is_overlay,
         item.batch_key.render_queue,
+        item.batch_key.is_transparent(),
         item._opaque_depth_bucket,
         item.batch_key_hash,
     );
@@ -367,15 +366,15 @@ fn render_queue_orders_alpha_test_transparent_and_overlay_ranges() {
 
 #[test]
 fn pack_sort_prefix_orders_overlay_after_main() {
-    let main = pack_sort_prefix(false, UNITY_RENDER_QUEUE_TRANSPARENT, 0, 0);
-    let overlay = pack_sort_prefix(true, 0, 0, 0);
+    let main = pack_sort_prefix(false, UNITY_RENDER_QUEUE_TRANSPARENT, true, 0, 0);
+    let overlay = pack_sort_prefix(true, 0, true, 0, 0);
     assert!(main < overlay);
 }
 
 #[test]
 fn pack_sort_prefix_orders_lower_render_queue_first() {
-    let lo = pack_sort_prefix(false, 0, 0, 0);
-    let hi = pack_sort_prefix(false, UNITY_RENDER_QUEUE_TRANSPARENT, 0, 0);
+    let lo = pack_sort_prefix(false, 0, false, 0, 0);
+    let hi = pack_sort_prefix(false, UNITY_RENDER_QUEUE_TRANSPARENT, false, 0, 0);
     assert!(lo < hi);
 }
 
@@ -384,10 +383,11 @@ fn pack_sort_prefix_zeros_depth_and_hash_for_transparent() {
     let with_depth_and_hash = pack_sort_prefix(
         false,
         UNITY_RENDER_QUEUE_TRANSPARENT,
+        true,
         200,
         0xDEAD_BEEF_DEAD_BEEF,
     );
-    let bare = pack_sort_prefix(false, UNITY_RENDER_QUEUE_TRANSPARENT, 0, 0);
+    let bare = pack_sort_prefix(false, UNITY_RENDER_QUEUE_TRANSPARENT, true, 0, 0);
     assert_eq!(
         with_depth_and_hash, bare,
         "transparent draws must share a key within their (overlay, render_queue) bucket"
@@ -396,11 +396,11 @@ fn pack_sort_prefix_zeros_depth_and_hash_for_transparent() {
 
 #[test]
 fn pack_sort_prefix_keeps_depth_and_hash_for_opaque() {
-    let near = pack_sort_prefix(false, 0, 10, 0);
-    let far = pack_sort_prefix(false, 0, 200, 0);
+    let near = pack_sort_prefix(false, 0, false, 10, 0);
+    let far = pack_sort_prefix(false, 0, false, 200, 0);
     assert!(near < far);
-    let same_depth_lo_hash = pack_sort_prefix(false, 0, 10, 0);
-    let same_depth_hi_hash = pack_sort_prefix(false, 0, 10, u64::MAX);
+    let same_depth_lo_hash = pack_sort_prefix(false, 0, false, 10, 0);
+    let same_depth_hi_hash = pack_sort_prefix(false, 0, false, 10, u64::MAX);
     assert!(same_depth_lo_hash < same_depth_hi_hash);
 }
 

--- a/crates/renderide/src/world_mesh/instances.rs
+++ b/crates/renderide/src/world_mesh/instances.rs
@@ -19,7 +19,7 @@ use rayon::prelude::*;
 
 use crate::materials::{
     RasterPipelineKind, ShaderPermutation, UNITY_RENDER_QUEUE_ALPHA_TEST,
-    embedded_stem_depth_prepass_pass, render_queue_is_transparent,
+    embedded_stem_depth_prepass_pass,
 };
 use crate::render_phase::{RenderPhaseKey, RenderPhaseSet};
 
@@ -459,7 +459,6 @@ fn depth_prepass_item_eligible(item: &WorldMeshDrawItem, shader_perm: ShaderPerm
     let key = &item.batch_key;
     !item.is_overlay
         && key.render_queue < UNITY_RENDER_QUEUE_ALPHA_TEST
-        && !render_queue_is_transparent(key.render_queue)
         && !key.alpha_blended
         && !key.blend_mode.is_transparent()
         && !key.embedded_requires_intersection_pass

--- a/crates/renderide/src/world_mesh/instances/tests.rs
+++ b/crates/renderide/src/world_mesh/instances/tests.rs
@@ -27,6 +27,7 @@ fn refresh_sort_keys(item: &mut WorldMeshDrawItem) {
     item.sort_prefix = pack_sort_prefix(
         item.is_overlay,
         item.batch_key.render_queue,
+        item.batch_key.is_transparent(),
         item._opaque_depth_bucket,
         item.batch_key_hash,
     );

--- a/crates/renderide/src/world_mesh/materials/key.rs
+++ b/crates/renderide/src/world_mesh/materials/key.rs
@@ -11,7 +11,7 @@ use super::transparent::TransparentMaterialClass;
 /// Groups draws that can share the same raster pipeline, material bind data, and Unity render-queue
 /// ordering bucket (Unity material +
 /// [`MaterialPropertyBlock`](https://docs.unity3d.com/ScriptReference/MaterialPropertyBlock.html)-style slot0).
-#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct MaterialDrawBatchKey {
     /// Resolved from host `set_shader` -> [`crate::materials::resolve_raster_pipeline`].
     pub pipeline: RasterPipelineKind,
@@ -95,4 +95,34 @@ pub fn compute_batch_key_hash(key: &MaterialDrawBatchKey) -> u64 {
     let mut h = ahash::AHasher::default();
     key.hash(&mut h);
     h.finish()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MaterialBlendMode, MaterialDrawBatchKey};
+    use crate::materials::{UNITY_RENDER_QUEUE_TRANSPARENT, UNITY_TRANSPARENT_RENDER_QUEUE_MIN};
+
+    #[test]
+    fn transparent_sorting_starts_at_transparent_queue_for_opaque_blend() {
+        let mut key = MaterialDrawBatchKey {
+            render_queue: UNITY_RENDER_QUEUE_TRANSPARENT - 1,
+            blend_mode: MaterialBlendMode::Opaque,
+            ..Default::default()
+        };
+        assert!(!key.is_transparent());
+        key.render_queue = UNITY_RENDER_QUEUE_TRANSPARENT;
+        assert!(key.is_transparent());
+    }
+
+    #[test]
+    fn transparent_sorting_starts_at_lower_transparent_queue_for_non_opaque_blend() {
+        let mut key = MaterialDrawBatchKey {
+            render_queue: UNITY_TRANSPARENT_RENDER_QUEUE_MIN - 1,
+            blend_mode: MaterialBlendMode::UnityBlend { src: 5, dst: 10 },
+            ..Default::default()
+        };
+        assert!(!key.is_transparent());
+        key.render_queue = UNITY_TRANSPARENT_RENDER_QUEUE_MIN;
+        assert!(key.is_transparent());
+    }
 }

--- a/crates/renderide/src/world_mesh/materials/key.rs
+++ b/crates/renderide/src/world_mesh/materials/key.rs
@@ -3,6 +3,7 @@
 use crate::materials::{
     EmbeddedTangentFallbackMode, MaterialBlendMode, MaterialRenderState, RasterFrontFace,
     RasterPipelineKind, RasterPrimitiveTopology, SceneColorSnapshotMode,
+    UNITY_RENDER_QUEUE_TRANSPARENT, UNITY_TRANSPARENT_RENDER_QUEUE_MIN,
 };
 
 use super::transparent::TransparentMaterialClass;
@@ -69,6 +70,19 @@ pub struct MaterialDrawBatchKey {
     pub alpha_blended: bool,
     /// Renderer-local transparent behavior class inferred from existing material and shader state.
     pub transparent_class: TransparentMaterialClass,
+}
+
+impl MaterialDrawBatchKey {
+    #[inline]
+    pub fn is_transparent(&self) -> bool {
+        render_queue_is_transparent(self.render_queue, self.blend_mode.is_transparent())
+    }
+}
+
+#[inline]
+pub fn render_queue_is_transparent(render_queue: i32, transparent_blend_mode: bool) -> bool {
+    render_queue >= UNITY_RENDER_QUEUE_TRANSPARENT
+        || (transparent_blend_mode && render_queue >= UNITY_TRANSPARENT_RENDER_QUEUE_MIN)
 }
 
 /// Computes a 64-bit content hash for `key` used by the draw-sort comparator's primary tiebreaker.

--- a/crates/renderide/src/world_mesh/materials/transparent.rs
+++ b/crates/renderide/src/world_mesh/materials/transparent.rs
@@ -1,6 +1,7 @@
 //! Transparent material compatibility classes derived from renderer-local material state.
 
-use crate::materials::{MaterialBlendMode, MaterialRenderState, render_queue_is_transparent};
+use crate::materials::{MaterialBlendMode, MaterialRenderState};
+use crate::world_mesh::materials::key::render_queue_is_transparent;
 
 /// Renderer-local transparent behavior bucket inferred from existing material and shader state.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
@@ -72,10 +73,8 @@ pub(super) struct TransparentMaterialClassInput {
 pub(super) fn transparent_class_for_material(
     input: TransparentMaterialClassInput,
 ) -> TransparentMaterialClass {
-    let transparent_queue = render_queue_is_transparent(input.render_queue);
-    let transparent_like = transparent_queue
-        || input.alpha_blended
-        || input.blend_mode.is_transparent()
+    let transparent_like = input.alpha_blended
+        || render_queue_is_transparent(input.render_queue, input.blend_mode.is_transparent())
         || input.uses_scene_color_snapshot
         || input.render_state.depth_write == Some(false);
     if !transparent_like {
@@ -163,6 +162,7 @@ mod tests {
         ] {
             let mut value = input();
             value.blend_mode = blend_mode;
+            value.render_queue = 2600;
 
             assert_eq!(
                 transparent_class_for_material(value),

--- a/crates/renderide/src/world_mesh/phase_classification.rs
+++ b/crates/renderide/src/world_mesh/phase_classification.rs
@@ -1,6 +1,6 @@
 //! Shared material-to-world-mesh-phase classification.
 
-use crate::materials::{UNITY_RENDER_QUEUE_ALPHA_TEST, render_queue_is_transparent};
+use crate::materials::UNITY_RENDER_QUEUE_ALPHA_TEST;
 use crate::world_mesh::MaterialDrawBatchKey;
 
 use super::instances::WorldMeshPhase;
@@ -36,9 +36,7 @@ pub(crate) fn classify_world_mesh_batch(key: &MaterialDrawBatchKey) -> WorldMesh
 
 /// Returns whether a regular forward draw must render after the skybox/background draw.
 fn regular_window_records_after_skybox(key: &MaterialDrawBatchKey) -> bool {
-    key.alpha_blended
-        || render_queue_is_transparent(key.render_queue)
-        || key.render_state.depth_write == Some(false)
+    key.alpha_blended || key.is_transparent() || key.render_state.depth_write == Some(false)
 }
 
 /// Selects the primary phase for one same-batch-key window.

--- a/crates/renderide/src/world_mesh/test_fixtures.rs
+++ b/crates/renderide/src/world_mesh/test_fixtures.rs
@@ -97,6 +97,7 @@ pub fn dummy_world_mesh_draw_item(spec: DummyDrawItemSpec) -> WorldMeshDrawItem 
     let sort_prefix = crate::world_mesh::draw_prep::pack_sort_prefix(
         false,
         batch_key.render_queue,
+        batch_key.is_transparent(),
         0,
         batch_key_hash,
     );


### PR DESCRIPTION
Currently, everything with a render queue over 2501 is considered as transparent with regards to many parts of the depths ordering process.
This can clash with the behavior of unity, where for example materials with Opaque blend types can go up to 2999 with minor side effects.

The idea of this fix is to use a different threshold for the transparency criterion depending on the blend mode of the material.
For non-opaque materials, 2501 will stay used as it is currently, minimizing impact on the current behavior. For opaque materials, 3000 will be used instead, which fixes a handful of issues, in particular #488.

I have tested a variety of worlds and objects, and it seems mostly okay, but I’d love some community help to check the impacts of this change.