### PR TITLE
use XR_EXT_palm_pose when available to position the hand

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,189 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="ALL" />
+  </component>
+  <component name="CargoProjects">
+    <cargoProject FILE="$PROJECT_DIR$/Cargo.toml">
+      <package file="$PROJECT_DIR$/crates/bootstrapper">
+        <feature name="default" enabled="true" />
+      </package>
+      <package file="$PROJECT_DIR$/crates/interprocess">
+        <feature name="default" enabled="true" />
+      </package>
+      <package file="$PROJECT_DIR$/crates/logger">
+        <feature name="default" enabled="true" />
+      </package>
+      <package file="$PROJECT_DIR$/crates/renderide">
+        <feature name="default" enabled="true" />
+      </package>
+      <package file="$PROJECT_DIR$/crates/renderide-shared">
+        <feature name="default" enabled="true" />
+      </package>
+      <package file="$PROJECT_DIR$/crates/renderide-test">
+        <feature name="default" enabled="true" />
+      </package>
+    </cargoProject>
+  </component>
+  <component name="ChangeListManager">
+    <list default="true" id="9fe610a3-e155-456d-b1d4-9c424c4f8b9c" name="Changes" comment="">
+      <change beforePath="$PROJECT_DIR$/crates/renderide/assets/xr/actions.toml" beforeDir="false" afterPath="$PROJECT_DIR$/crates/renderide/assets/xr/actions.toml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/crates/renderide/assets/xr/bindings/bytedance_pico4_controller.toml" beforeDir="false" afterPath="$PROJECT_DIR$/crates/renderide/assets/xr/bindings/bytedance_pico4_controller.toml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/crates/renderide/assets/xr/bindings/bytedance_pico_neo3_controller.toml" beforeDir="false" afterPath="$PROJECT_DIR$/crates/renderide/assets/xr/bindings/bytedance_pico_neo3_controller.toml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/crates/renderide/assets/xr/bindings/facebook_touch_controller_pro.toml" beforeDir="false" afterPath="$PROJECT_DIR$/crates/renderide/assets/xr/bindings/facebook_touch_controller_pro.toml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/crates/renderide/assets/xr/bindings/hp_mixed_reality_controller.toml" beforeDir="false" afterPath="$PROJECT_DIR$/crates/renderide/assets/xr/bindings/hp_mixed_reality_controller.toml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/crates/renderide/assets/xr/bindings/htc_vive_controller.toml" beforeDir="false" afterPath="$PROJECT_DIR$/crates/renderide/assets/xr/bindings/htc_vive_controller.toml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/crates/renderide/assets/xr/bindings/htc_vive_cosmos_controller.toml" beforeDir="false" afterPath="$PROJECT_DIR$/crates/renderide/assets/xr/bindings/htc_vive_cosmos_controller.toml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/crates/renderide/assets/xr/bindings/htc_vive_focus3_controller.toml" beforeDir="false" afterPath="$PROJECT_DIR$/crates/renderide/assets/xr/bindings/htc_vive_focus3_controller.toml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/crates/renderide/assets/xr/bindings/meta_touch_controller_plus.toml" beforeDir="false" afterPath="$PROJECT_DIR$/crates/renderide/assets/xr/bindings/meta_touch_controller_plus.toml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/crates/renderide/assets/xr/bindings/microsoft_motion_controller.toml" beforeDir="false" afterPath="$PROJECT_DIR$/crates/renderide/assets/xr/bindings/microsoft_motion_controller.toml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/crates/renderide/assets/xr/bindings/oculus_touch_controller.toml" beforeDir="false" afterPath="$PROJECT_DIR$/crates/renderide/assets/xr/bindings/oculus_touch_controller.toml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/crates/renderide/assets/xr/bindings/samsung_odyssey_controller.toml" beforeDir="false" afterPath="$PROJECT_DIR$/crates/renderide/assets/xr/bindings/samsung_odyssey_controller.toml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/crates/renderide/assets/xr/bindings/valve_index_controller.toml" beforeDir="false" afterPath="$PROJECT_DIR$/crates/renderide/assets/xr/bindings/valve_index_controller.toml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/crates/renderide/src/xr/bootstrap/extensions.rs" beforeDir="false" afterPath="$PROJECT_DIR$/crates/renderide/src/xr/bootstrap/extensions.rs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/crates/renderide/src/xr/bootstrap/instance.rs" beforeDir="false" afterPath="$PROJECT_DIR$/crates/renderide/src/xr/bootstrap/instance.rs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/crates/renderide/src/xr/input/bindings.rs" beforeDir="false" afterPath="$PROJECT_DIR$/crates/renderide/src/xr/input/bindings.rs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/crates/renderide/src/xr/input/frame.rs" beforeDir="false" afterPath="$PROJECT_DIR$/crates/renderide/src/xr/input/frame.rs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/crates/renderide/src/xr/input/openxr_actions.rs" beforeDir="false" afterPath="$PROJECT_DIR$/crates/renderide/src/xr/input/openxr_actions.rs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/crates/renderide/src/xr/input/openxr_actions/action_handles.rs" beforeDir="false" afterPath="$PROJECT_DIR$/crates/renderide/src/xr/input/openxr_actions/action_handles.rs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/crates/renderide/src/xr/input/openxr_input.rs" beforeDir="false" afterPath="$PROJECT_DIR$/crates/renderide/src/xr/input/openxr_input.rs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/crates/renderide/src/xr/input/pose.rs" beforeDir="false" afterPath="$PROJECT_DIR$/crates/renderide/src/xr/input/pose.rs" afterDir="false" />
+    </list>
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="ExecutionTargetManager" SELECTED_TARGET="RsBuildProfile:test" />
+  <component name="FileTemplateManagerImpl">
+    <option name="RECENT_TEMPLATES">
+      <list>
+        <option value="Rust File" />
+      </list>
+    </option>
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="MacroExpansionManager">
+    <option name="directoryName" value="G5E3BuhA" />
+  </component>
+  <component name="ProjectColorInfo">{
+  &quot;customColor&quot;: &quot;&quot;,
+  &quot;associatedIndex&quot;: 0
+}</component>
+  <component name="ProjectId" id="3E5eAQBF4oflHmBPJWEsNFNxfqG" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;ModuleVcsDetector.initialDetectionPerformed&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.TerminalTabsStorage.copyFrom.TerminalArrangementManager.252&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.rust.reset.selective.auto.import&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.typescript.service.memoryLimit.init&quot;: &quot;true&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;openxr-grip-surface-pose&quot;,
+    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
+    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
+    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
+    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
+    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
+    &quot;org.rust.cargo.project.model.PROJECT_DISCOVERY&quot;: &quot;true&quot;,
+    &quot;org.rust.first.attach.projects&quot;: &quot;true&quot;,
+    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
+  }
+}</component>
+  <component name="RunManager" selected="Cargo.Test Renderide">
+    <configuration name="Run renderide-renderer" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+      <option name="command" value="run --package renderide --bin renderide-renderer" />
+      <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+      <envs />
+      <option name="emulateTerminal" value="true" />
+      <option name="channel" value="DEFAULT" />
+      <option name="requiredFeatures" value="true" />
+      <option name="allFeatures" value="false" />
+      <option name="withSudo" value="false" />
+      <option name="buildTarget" value="REMOTE" />
+      <option name="backtrace" value="SHORT" />
+      <option name="isRedirectInput" value="false" />
+      <option name="redirectInputPath" value="" />
+      <method v="2">
+        <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+      </method>
+    </configuration>
+    <configuration name="Run renderide-test" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+      <option name="command" value="run --package renderide-test --bin renderide-test" />
+      <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+      <envs />
+      <option name="emulateTerminal" value="true" />
+      <option name="channel" value="DEFAULT" />
+      <option name="requiredFeatures" value="true" />
+      <option name="allFeatures" value="false" />
+      <option name="withSudo" value="false" />
+      <option name="buildTarget" value="REMOTE" />
+      <option name="backtrace" value="SHORT" />
+      <option name="isRedirectInput" value="false" />
+      <option name="redirectInputPath" value="" />
+      <method v="2">
+        <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+      </method>
+    </configuration>
+    <configuration name="Run renderide" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+      <option name="command" value="run --package bootstrapper --bin renderide" />
+      <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+      <envs />
+      <option name="emulateTerminal" value="true" />
+      <option name="channel" value="DEFAULT" />
+      <option name="requiredFeatures" value="true" />
+      <option name="allFeatures" value="false" />
+      <option name="withSudo" value="false" />
+      <option name="buildTarget" value="REMOTE" />
+      <option name="backtrace" value="SHORT" />
+      <option name="isRedirectInput" value="false" />
+      <option name="redirectInputPath" value="" />
+      <method v="2">
+        <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+      </method>
+    </configuration>
+    <configuration name="Test Renderide" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+      <option name="buildProfileId" value="test" />
+      <option name="command" value="test --workspace" />
+      <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+      <envs />
+      <option name="emulateTerminal" value="true" />
+      <option name="channel" value="DEFAULT" />
+      <option name="requiredFeatures" value="true" />
+      <option name="allFeatures" value="false" />
+      <option name="withSudo" value="false" />
+      <option name="buildTarget" value="REMOTE" />
+      <option name="backtrace" value="SHORT" />
+      <option name="isRedirectInput" value="false" />
+      <option name="redirectInputPath" value="" />
+      <method v="2">
+        <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+      </method>
+    </configuration>
+  </component>
+  <component name="RustProjectSettings">
+    <option name="toolchainHomeDirectory" value="/usr/bin" />
+  </component>
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="9fe610a3-e155-456d-b1d4-9c424c4f8b9c" name="Changes" comment="" />
+      <created>1779472713339</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1779472713339</updated>
+      <workItem from="1779472714411" duration="12495000" />
+      <workItem from="1779500250219" duration="939000" />
+      <workItem from="1779555315741" duration="5236000" />
+    </task>
+    <servers />
+  </component>
+  <component name="TypeScriptGeneratedFilesManager">
+    <option name="version" value="3" />
+  </component>
+</project>

--- a/crates/renderide/assets/xr/actions.toml
+++ b/crates/renderide/assets/xr/actions.toml
@@ -35,6 +35,16 @@ id = "right_aim_pose"
 type = "pose"
 localized_name = "Right aim pose"
 
+[[action]]
+id = "left_palm_ext_pose"
+type = "pose"
+localized_name = "Left palm_ext pose"
+
+[[action]]
+id = "right_palm_ext_pose"
+type = "pose"
+localized_name = "Right palm_ext pose"
+
 # --- Trigger ---
 
 [[action]]

--- a/crates/renderide/assets/xr/bindings/bytedance_pico4_controller.toml
+++ b/crates/renderide/assets/xr/bindings/bytedance_pico4_controller.toml
@@ -8,11 +8,11 @@ path = "/user/hand/left/input/grip/pose"
 action = "right_grip_pose"
 path = "/user/hand/right/input/grip/pose"
 [[binding]]
-action = "left_aim_pose"
-path = "/user/hand/left/input/aim/pose"
+action = "left_palm_ext_pose"
+path = "/user/hand/left/input/palm_ext/pose"
 [[binding]]
-action = "right_aim_pose"
-path = "/user/hand/right/input/aim/pose"
+action = "right_palm_ext_pose"
+path = "/user/hand/right/input/palm_ext/pose"
 
 [[binding]]
 action = "left_trigger"

--- a/crates/renderide/assets/xr/bindings/bytedance_pico_neo3_controller.toml
+++ b/crates/renderide/assets/xr/bindings/bytedance_pico_neo3_controller.toml
@@ -8,11 +8,11 @@ path = "/user/hand/left/input/grip/pose"
 action = "right_grip_pose"
 path = "/user/hand/right/input/grip/pose"
 [[binding]]
-action = "left_aim_pose"
-path = "/user/hand/left/input/aim/pose"
+action = "left_palm_ext_pose"
+path = "/user/hand/left/input/palm_ext/pose"
 [[binding]]
-action = "right_aim_pose"
-path = "/user/hand/right/input/aim/pose"
+action = "right_palm_ext_pose"
+path = "/user/hand/right/input/palm_ext/pose"
 
 [[binding]]
 action = "left_trigger"

--- a/crates/renderide/assets/xr/bindings/facebook_touch_controller_pro.toml
+++ b/crates/renderide/assets/xr/bindings/facebook_touch_controller_pro.toml
@@ -8,11 +8,11 @@ path = "/user/hand/left/input/grip/pose"
 action = "right_grip_pose"
 path = "/user/hand/right/input/grip/pose"
 [[binding]]
-action = "left_aim_pose"
-path = "/user/hand/left/input/aim/pose"
+action = "left_palm_ext_pose"
+path = "/user/hand/left/input/palm_ext/pose"
 [[binding]]
-action = "right_aim_pose"
-path = "/user/hand/right/input/aim/pose"
+action = "right_palm_ext_pose"
+path = "/user/hand/right/input/palm_ext/pose"
 
 [[binding]]
 action = "left_trigger"

--- a/crates/renderide/assets/xr/bindings/hp_mixed_reality_controller.toml
+++ b/crates/renderide/assets/xr/bindings/hp_mixed_reality_controller.toml
@@ -8,11 +8,11 @@ path = "/user/hand/left/input/grip/pose"
 action = "right_grip_pose"
 path = "/user/hand/right/input/grip/pose"
 [[binding]]
-action = "left_aim_pose"
-path = "/user/hand/left/input/aim/pose"
+action = "left_palm_ext_pose"
+path = "/user/hand/left/input/palm_ext/pose"
 [[binding]]
-action = "right_aim_pose"
-path = "/user/hand/right/input/aim/pose"
+action = "right_palm_ext_pose"
+path = "/user/hand/right/input/palm_ext/pose"
 
 [[binding]]
 action = "left_trigger"

--- a/crates/renderide/assets/xr/bindings/htc_vive_controller.toml
+++ b/crates/renderide/assets/xr/bindings/htc_vive_controller.toml
@@ -7,11 +7,11 @@ path = "/user/hand/left/input/grip/pose"
 action = "right_grip_pose"
 path = "/user/hand/right/input/grip/pose"
 [[binding]]
-action = "left_aim_pose"
-path = "/user/hand/left/input/aim/pose"
+action = "left_palm_ext_pose"
+path = "/user/hand/left/input/palm_ext/pose"
 [[binding]]
-action = "right_aim_pose"
-path = "/user/hand/right/input/aim/pose"
+action = "right_palm_ext_pose"
+path = "/user/hand/right/input/palm_ext/pose"
 
 [[binding]]
 action = "left_trigger"

--- a/crates/renderide/assets/xr/bindings/htc_vive_cosmos_controller.toml
+++ b/crates/renderide/assets/xr/bindings/htc_vive_cosmos_controller.toml
@@ -8,11 +8,11 @@ path = "/user/hand/left/input/grip/pose"
 action = "right_grip_pose"
 path = "/user/hand/right/input/grip/pose"
 [[binding]]
-action = "left_aim_pose"
-path = "/user/hand/left/input/aim/pose"
+action = "left_palm_ext_pose"
+path = "/user/hand/left/input/palm_ext/pose"
 [[binding]]
-action = "right_aim_pose"
-path = "/user/hand/right/input/aim/pose"
+action = "right_palm_ext_pose"
+path = "/user/hand/right/input/palm_ext/pose"
 
 [[binding]]
 action = "left_trigger"

--- a/crates/renderide/assets/xr/bindings/htc_vive_focus3_controller.toml
+++ b/crates/renderide/assets/xr/bindings/htc_vive_focus3_controller.toml
@@ -8,11 +8,11 @@ path = "/user/hand/left/input/grip/pose"
 action = "right_grip_pose"
 path = "/user/hand/right/input/grip/pose"
 [[binding]]
-action = "left_aim_pose"
-path = "/user/hand/left/input/aim/pose"
+action = "left_palm_ext_pose"
+path = "/user/hand/left/input/palm_ext/pose"
 [[binding]]
-action = "right_aim_pose"
-path = "/user/hand/right/input/aim/pose"
+action = "right_palm_ext_pose"
+path = "/user/hand/right/input/palm_ext/pose"
 
 [[binding]]
 action = "left_trigger"

--- a/crates/renderide/assets/xr/bindings/khr_generic_controller.toml
+++ b/crates/renderide/assets/xr/bindings/khr_generic_controller.toml
@@ -7,12 +7,6 @@ path = "/user/hand/left/input/grip/pose"
 [[binding]]
 action = "right_grip_pose"
 path = "/user/hand/right/input/grip/pose"
-[[binding]]
-action = "left_aim_pose"
-path = "/user/hand/left/input/aim/pose"
-[[binding]]
-action = "right_aim_pose"
-path = "/user/hand/right/input/aim/pose"
 
 [[binding]]
 action = "left_trigger"

--- a/crates/renderide/assets/xr/bindings/khr_simple_controller.toml
+++ b/crates/renderide/assets/xr/bindings/khr_simple_controller.toml
@@ -6,12 +6,6 @@ path = "/user/hand/left/input/grip/pose"
 [[binding]]
 action = "right_grip_pose"
 path = "/user/hand/right/input/grip/pose"
-[[binding]]
-action = "left_aim_pose"
-path = "/user/hand/left/input/aim/pose"
-[[binding]]
-action = "right_aim_pose"
-path = "/user/hand/right/input/aim/pose"
 
 [[binding]]
 action = "left_select"

--- a/crates/renderide/assets/xr/bindings/meta_touch_controller_plus.toml
+++ b/crates/renderide/assets/xr/bindings/meta_touch_controller_plus.toml
@@ -8,11 +8,11 @@ path = "/user/hand/left/input/grip/pose"
 action = "right_grip_pose"
 path = "/user/hand/right/input/grip/pose"
 [[binding]]
-action = "left_aim_pose"
-path = "/user/hand/left/input/aim/pose"
+action = "left_palm_ext_pose"
+path = "/user/hand/left/input/palm_ext/pose"
 [[binding]]
-action = "right_aim_pose"
-path = "/user/hand/right/input/aim/pose"
+action = "right_palm_ext_pose"
+path = "/user/hand/right/input/palm_ext/pose"
 
 [[binding]]
 action = "left_trigger"

--- a/crates/renderide/assets/xr/bindings/microsoft_motion_controller.toml
+++ b/crates/renderide/assets/xr/bindings/microsoft_motion_controller.toml
@@ -7,11 +7,11 @@ path = "/user/hand/left/input/grip/pose"
 action = "right_grip_pose"
 path = "/user/hand/right/input/grip/pose"
 [[binding]]
-action = "left_aim_pose"
-path = "/user/hand/left/input/aim/pose"
+action = "left_palm_ext_pose"
+path = "/user/hand/left/input/palm_ext/pose"
 [[binding]]
-action = "right_aim_pose"
-path = "/user/hand/right/input/aim/pose"
+action = "right_palm_ext_pose"
+path = "/user/hand/right/input/palm_ext/pose"
 
 [[binding]]
 action = "left_trigger"

--- a/crates/renderide/assets/xr/bindings/oculus_touch_controller.toml
+++ b/crates/renderide/assets/xr/bindings/oculus_touch_controller.toml
@@ -7,11 +7,11 @@ path = "/user/hand/left/input/grip/pose"
 action = "right_grip_pose"
 path = "/user/hand/right/input/grip/pose"
 [[binding]]
-action = "left_aim_pose"
-path = "/user/hand/left/input/aim/pose"
+action = "left_palm_ext_pose"
+path = "/user/hand/left/input/palm_ext/pose"
 [[binding]]
-action = "right_aim_pose"
-path = "/user/hand/right/input/aim/pose"
+action = "right_palm_ext_pose"
+path = "/user/hand/right/input/palm_ext/pose"
 
 [[binding]]
 action = "left_trigger"

--- a/crates/renderide/assets/xr/bindings/samsung_odyssey_controller.toml
+++ b/crates/renderide/assets/xr/bindings/samsung_odyssey_controller.toml
@@ -8,11 +8,11 @@ path = "/user/hand/left/input/grip/pose"
 action = "right_grip_pose"
 path = "/user/hand/right/input/grip/pose"
 [[binding]]
-action = "left_aim_pose"
-path = "/user/hand/left/input/aim/pose"
+action = "left_palm_ext_pose"
+path = "/user/hand/left/input/palm_ext/pose"
 [[binding]]
-action = "right_aim_pose"
-path = "/user/hand/right/input/aim/pose"
+action = "right_palm_ext_pose"
+path = "/user/hand/right/input/palm_ext/pose"
 
 [[binding]]
 action = "left_trigger"

--- a/crates/renderide/assets/xr/bindings/valve_index_controller.toml
+++ b/crates/renderide/assets/xr/bindings/valve_index_controller.toml
@@ -7,11 +7,11 @@ path = "/user/hand/left/input/grip/pose"
 action = "right_grip_pose"
 path = "/user/hand/right/input/grip/pose"
 [[binding]]
-action = "left_aim_pose"
-path = "/user/hand/left/input/aim/pose"
+action = "left_palm_ext_pose"
+path = "/user/hand/left/input/palm_ext/pose"
 [[binding]]
-action = "right_aim_pose"
-path = "/user/hand/right/input/aim/pose"
+action = "right_palm_ext_pose"
+path = "/user/hand/right/input/palm_ext/pose"
 
 [[binding]]
 action = "left_trigger"

--- a/crates/renderide/src/xr/bootstrap/extensions.rs
+++ b/crates/renderide/src/xr/bootstrap/extensions.rs
@@ -87,6 +87,12 @@ const OPTIONAL_EXTENSIONS: &[OpenxrExtensionEntry] = &[
         enable: |set, v| set.meta_touch_controller_plus = v,
         feeds_profile_gate: Some(|gates, v| gates.meta_touch_controller_plus = v),
     },
+    OpenxrExtensionEntry {
+        log_name: "XR_EXT_palm_pose",
+        is_available: |set| set.ext_palm_pose,
+        enable: |set, v| set.ext_palm_pose = v,
+        feeds_profile_gate: Some(|gates, v| gates.palm_pose = v),
+    },
 ];
 
 /// Mirrors each [`OPTIONAL_EXTENSIONS`] entry from `available` into `enabled` and, for
@@ -118,6 +124,7 @@ pub(super) fn empty_profile_gates() -> ProfileExtensionGates {
         htc_vive_focus3_controller_interaction: false,
         fb_touch_controller_pro: false,
         meta_touch_controller_plus: false,
+        palm_pose: false,
     }
 }
 

--- a/crates/renderide/src/xr/input/bindings.rs
+++ b/crates/renderide/src/xr/input/bindings.rs
@@ -35,6 +35,8 @@ pub struct ProfileExtensionGates {
     pub fb_touch_controller_pro: bool,
     /// `XR_META_touch_controller_plus`.
     pub meta_touch_controller_plus: bool,
+    /// `XR_EXT_palm_pose`.
+    pub palm_pose: bool,
 }
 
 impl ProfileExtensionGates {
@@ -113,10 +115,17 @@ pub(super) fn apply_suggested_interaction_bindings(
             continue;
         }
 
+        // do not suggest palm_ext bindings if the extension is not available, doing so will make the
+        // runtime reject our bindings.
+        let profile_bindings = profile
+            .bindings
+            .iter()
+            .filter(|b| gates.palm_pose || !b.path.contains("palm_ext"));
+
         let profile_path = instance.string_to_path(&profile.profile)?;
 
         let mut bindings: Vec<xr::Binding<'_>> = Vec::with_capacity(profile.bindings.len());
-        for entry in &profile.bindings {
+        for entry in profile_bindings {
             let Some(handle) = actions_by_id.get(entry.action.as_str()) else {
                 logger::error!(
                     "OpenXR manifest invariant: binding for '{}' in '{}' has no matching action handle",
@@ -167,8 +176,8 @@ pub(super) fn build_action_handle_map(
 
     put!(Pose, left_grip_pose);
     put!(Pose, right_grip_pose);
-    put!(Pose, left_aim_pose);
-    put!(Pose, right_aim_pose);
+    put!(Pose, left_palm_ext_pose);
+    put!(Pose, right_palm_ext_pose);
 
     put!(Float, left_trigger);
     put!(Float, right_trigger);
@@ -237,6 +246,7 @@ mod tests {
             htc_vive_focus3_controller_interaction: enabled,
             fb_touch_controller_pro: enabled,
             meta_touch_controller_plus: enabled,
+            palm_pose: enabled,
         }
     }
 

--- a/crates/renderide/src/xr/input/frame.rs
+++ b/crates/renderide/src/xr/input/frame.rs
@@ -2,13 +2,10 @@
 
 use glam::{Quat, Vec3};
 
-use crate::shared::Chirality;
-
-use super::pose::{
-    bound_hand_pose_defaults, controller_pose_from_aim, openxr_grip_to_steamvr_raw,
-    touch_pose_correction,
-};
 use super::profile::ActiveControllerProfile;
+use crate::shared::Chirality;
+use crate::xr::input::pose::{grip_to_palm_ext_pose, hand_pose_defaults};
+use crate::xr::session::openxr_tracking_pose_to_host;
 
 /// Resolved controller and optional bound-hand pose in tracking space.
 #[derive(Clone, Copy)]
@@ -25,33 +22,32 @@ pub(super) struct ControllerFrame {
     pub(super) hand_rotation: Quat,
 }
 
-/// Per-profile pose resolution. Grip poses are preferred; aim poses are used only as a fallback.
-/// The selected OpenXR pose is converted to a SteamVR raw-style controller pose before any
-/// host-specific Touch correction is applied.
+/// Per-profile pose resolution. If a palm_ext pose is available we use that, otherwise we convert
+/// a grip pose into it using fixed offsets in [`grip_to_palm_ext_pose`].
+///
+/// The hand pose is currently hardcoded to match the palm_ext pose.
 pub(super) fn resolve_controller_frame(
     profile: ActiveControllerProfile,
     side: Chirality,
     grip_pose: Option<(Vec3, Quat)>,
-    aim_pose: Option<(Vec3, Quat)>,
+    palm_ext_pose: Option<(Vec3, Quat)>,
 ) -> Option<ControllerFrame> {
-    let (has_bound_hand, hand_position_default, hand_rotation_default) =
-        bound_hand_pose_defaults(profile, side);
-    let (grip_position, grip_rotation) = grip_pose.or_else(|| {
-        aim_pose.map(|(position, rotation)| controller_pose_from_aim(position, rotation))
-    })?;
-    let (position, rotation) =
-        openxr_grip_to_steamvr_raw(profile, side, grip_position, grip_rotation);
-    let (position, rotation) = match profile {
-        ActiveControllerProfile::Touch => touch_pose_correction(side, position, rotation),
-        _ => (position, rotation),
+    let (pos, rot) = if let Some(p) = palm_ext_pose {
+        p
+    } else if let Some(p) = grip_pose {
+        grip_to_palm_ext_pose(profile, side, p)
+    } else {
+        return None;
     };
 
+    let (position, rotation) = openxr_tracking_pose_to_host(pos, rot);
+    let (hand_position, hand_rotation) = hand_pose_defaults(side);
     Some(ControllerFrame {
         position,
         rotation,
-        has_bound_hand,
-        hand_position: hand_position_default,
-        hand_rotation: hand_rotation_default,
+        has_bound_hand: true,
+        hand_position,
+        hand_rotation,
     })
 }
 
@@ -62,9 +58,6 @@ mod tests {
     use crate::shared::Chirality;
     use crate::xr::session::openxr_tracking_pose_to_host;
 
-    use super::super::pose::{
-        controller_pose_from_aim, openxr_grip_to_steamvr_raw, touch_pose_correction,
-    };
     use super::super::profile::ActiveControllerProfile;
     use super::resolve_controller_frame;
 
@@ -94,219 +87,49 @@ mod tests {
     }
 
     #[test]
-    fn index_grip_is_raw_pose_corrected_with_identity_bound_hand() {
-        let grip_position = Vec3::new(0.2, 1.3, -0.4);
-        let grip_rotation = (Quat::from_rotation_y(0.6) * Quat::from_rotation_x(-0.2)).normalize();
-        let aim_position = Vec3::new(0.24, 1.34, -0.28);
-        let aim_rotation = (Quat::from_rotation_y(0.75) * Quat::from_rotation_x(-0.1)).normalize();
+    fn no_poses_available_return_none() {
+        assert!(
+            resolve_controller_frame(
+                ActiveControllerProfile::Generic,
+                Chirality::Left,
+                None,
+                None
+            )
+            .is_none()
+        );
+    }
 
+    #[test]
+    fn grip_pose_gets_offset() {
+        let grip_position = Vec3::new(0.3, 1.2, -0.5);
+        let grip_rotation = Quat::from_rotation_x(0.25).normalize();
         let frame = resolve_controller_frame(
-            ActiveControllerProfile::Index,
+            ActiveControllerProfile::Generic,
             Chirality::Left,
             Some((grip_position, grip_rotation)),
-            Some((aim_position, aim_rotation)),
-        )
-        .expect("frame");
-
-        let (expected_position, expected_rotation) = openxr_grip_to_steamvr_raw(
-            ActiveControllerProfile::Index,
-            Chirality::Left,
-            grip_position,
-            grip_rotation,
-        );
-        assert_vec3_near(frame.position, expected_position);
-        assert_quat_near(frame.rotation, expected_rotation);
-        assert!(frame.has_bound_hand);
-        assert_vec3_near(frame.hand_position, Vec3::ZERO);
-        assert_quat_near(frame.hand_rotation, Quat::IDENTITY);
-    }
-
-    #[test]
-    fn index_aim_fallback_is_raw_pose_corrected() {
-        let aim_position = Vec3::new(0.24, 1.34, -0.28);
-        let aim_rotation = (Quat::from_rotation_y(0.75) * Quat::from_rotation_x(-0.1)).normalize();
-        let frame = resolve_controller_frame(
-            ActiveControllerProfile::Index,
-            Chirality::Left,
             None,
-            Some((aim_position, aim_rotation)),
         )
         .expect("frame");
-        let (aim_grip_position, aim_grip_rotation) =
-            controller_pose_from_aim(aim_position, aim_rotation);
-        let (expected_position, expected_rotation) = openxr_grip_to_steamvr_raw(
-            ActiveControllerProfile::Index,
-            Chirality::Left,
-            aim_grip_position,
-            aim_grip_rotation,
-        );
-        assert_vec3_near(frame.position, expected_position);
-        assert_quat_near(frame.rotation, expected_rotation);
-    }
-
-    #[test]
-    fn generic_uses_aim_when_grip_missing() {
-        let aim_position = Vec3::new(0.1, 1.2, -0.3);
-        let aim_rotation = Quat::from_rotation_x(0.3);
-        let frame = resolve_controller_frame(
-            ActiveControllerProfile::Generic,
-            Chirality::Right,
-            None,
-            Some((aim_position, aim_rotation)),
-        )
-        .expect("frame");
-        let (aim_grip_position, aim_grip_rotation) =
-            controller_pose_from_aim(aim_position, aim_rotation);
-        let (expected_controller_position, expected_controller_rotation) =
-            openxr_tracking_pose_to_host(aim_grip_position, aim_grip_rotation);
-        assert_vec3_near(frame.position, expected_controller_position);
-        assert_quat_near(frame.rotation, expected_controller_rotation);
-    }
-
-    #[test]
-    fn touch_uses_aim_when_grip_missing() {
-        let aim_position = Vec3::new(-0.2, 1.1, -0.25);
-        let aim_rotation = Quat::from_rotation_y(-0.4);
-        let frame = resolve_controller_frame(
-            ActiveControllerProfile::Touch,
-            Chirality::Left,
-            None,
-            Some((aim_position, aim_rotation)),
-        )
-        .expect("frame");
-        let (aim_grip_position, aim_grip_rotation) =
-            controller_pose_from_aim(aim_position, aim_rotation);
-        let (raw_position, raw_rotation) = openxr_grip_to_steamvr_raw(
-            ActiveControllerProfile::Touch,
-            Chirality::Left,
-            aim_grip_position,
-            aim_grip_rotation,
-        );
-        let (expected_position, expected_rotation) =
-            touch_pose_correction(Chirality::Left, raw_position, raw_rotation);
-        assert_vec3_near(frame.position, expected_position);
-        assert_quat_near(frame.rotation, expected_rotation);
-    }
-
-    #[test]
-    fn touch_prefers_grip_when_both_present() {
-        let grip_position = Vec3::new(0.2, 1.3, -0.4);
-        let grip_rotation = (Quat::from_rotation_y(0.6) * Quat::from_rotation_x(-0.2)).normalize();
-        let aim_position = Vec3::new(0.5, 0.5, 0.5);
-        let aim_rotation = Quat::IDENTITY;
-        let frame = resolve_controller_frame(
-            ActiveControllerProfile::Touch,
-            Chirality::Left,
-            Some((grip_position, grip_rotation)),
-            Some((aim_position, aim_rotation)),
-        )
-        .expect("frame");
-        let (raw_position, raw_rotation) = openxr_grip_to_steamvr_raw(
-            ActiveControllerProfile::Touch,
-            Chirality::Left,
-            grip_position,
-            grip_rotation,
-        );
-        let (expected_pos, expected_rot) =
-            touch_pose_correction(Chirality::Left, raw_position, raw_rotation);
-        assert_vec3_near(frame.position, expected_pos);
-        assert_quat_near(frame.rotation, expected_rot);
-    }
-
-    #[test]
-    fn non_touch_profiles_skip_touch_correction() {
-        let grip_position = Vec3::new(0.3, 1.2, -0.5);
-        let grip_rotation = Quat::from_rotation_x(0.25).normalize();
-        for profile in [
-            ActiveControllerProfile::Index,
-            ActiveControllerProfile::ViveFocus3,
-            ActiveControllerProfile::Vive,
-            ActiveControllerProfile::Generic,
-        ] {
-            let frame = resolve_controller_frame(
-                profile,
-                Chirality::Right,
-                Some((grip_position, grip_rotation)),
-                None,
-            )
-            .unwrap_or_else(|| panic!("frame for {profile:?}"));
-            let (expected_position, expected_rotation) =
-                openxr_grip_to_steamvr_raw(profile, Chirality::Right, grip_position, grip_rotation);
-            assert_vec3_near(frame.position, expected_position);
-            assert_quat_near(frame.rotation, expected_rotation);
-        }
-    }
-
-    #[test]
-    fn identity_offset_profiles_pass_grip_through() {
-        let grip_position = Vec3::new(0.3, 1.2, -0.5);
-        let grip_rotation = Quat::from_rotation_x(0.25).normalize();
-        for profile in [
-            ActiveControllerProfile::Vive,
-            ActiveControllerProfile::WindowsMr,
-            ActiveControllerProfile::HpReverbG2,
-            ActiveControllerProfile::Pico4,
-            ActiveControllerProfile::PicoNeo3,
-            ActiveControllerProfile::ViveCosmos,
-            ActiveControllerProfile::Generic,
-            ActiveControllerProfile::Simple,
-        ] {
-            let frame = resolve_controller_frame(
-                profile,
-                Chirality::Right,
-                Some((grip_position, grip_rotation)),
-                None,
-            )
-            .unwrap_or_else(|| panic!("frame for {profile:?}"));
-            let (expected_position, expected_rotation) =
-                openxr_tracking_pose_to_host(grip_position, grip_rotation);
-            assert_vec3_near(frame.position, expected_position);
-            assert_quat_near(frame.rotation, expected_rotation);
-        }
-    }
-
-    #[test]
-    fn raw_corrected_profiles_shift_grip_pose() {
-        let grip_position = Vec3::new(0.3, 1.2, -0.5);
-        let grip_rotation = Quat::from_rotation_x(0.25).normalize();
-        let (host_grip_position, host_grip_rotation) =
+        let (original_position, original_rotation) =
             openxr_tracking_pose_to_host(grip_position, grip_rotation);
-        for profile in [
-            ActiveControllerProfile::Index,
-            ActiveControllerProfile::Touch,
-            ActiveControllerProfile::ViveFocus3,
-        ] {
-            let frame = resolve_controller_frame(
-                profile,
-                Chirality::Right,
-                Some((grip_position, grip_rotation)),
-                None,
-            )
-            .unwrap_or_else(|| panic!("frame for {profile:?}"));
-            assert!(
-                (frame.position - host_grip_position).length() > 0.05,
-                "{profile:?}: expected non-trivial raw-pose position correction",
-            );
-            assert!(
-                rotation_delta_angle(frame.rotation, host_grip_rotation) > 0.2,
-                "{profile:?}: expected non-trivial raw-pose rotation correction",
-            );
-        }
+
+        assert_ne!(frame.rotation, original_rotation);
+        assert_ne!(frame.position, original_position);
     }
 
     #[test]
-    fn bound_hand_offsets_do_not_change_controller_pose() {
-        let grip_position = Vec3::new(0.3, 1.2, -0.5);
-        let grip_rotation = Quat::from_rotation_x(0.25).normalize();
+    fn palm_ext_pose_gets_used_as_controller_pose_if_available() {
+        let palm_position = Vec3::new(0.3, 1.2, -0.5);
+        let palm_rotation = Quat::from_rotation_x(0.25).normalize();
         let frame = resolve_controller_frame(
             ActiveControllerProfile::Generic,
             Chirality::Left,
-            Some((grip_position, grip_rotation)),
-            None,
+            Some((Vec3::ZERO, Quat::IDENTITY)),
+            Some((palm_position, palm_rotation)),
         )
         .expect("frame");
         let (expected_position, expected_rotation) =
-            openxr_tracking_pose_to_host(grip_position, grip_rotation);
+            openxr_tracking_pose_to_host(palm_position, palm_rotation);
 
         assert_vec3_near(frame.position, expected_position);
         assert_quat_near(frame.rotation, expected_rotation);

--- a/crates/renderide/src/xr/input/hand_synth.rs
+++ b/crates/renderide/src/xr/input/hand_synth.rs
@@ -65,7 +65,7 @@ struct ControllerCurlInputs {
     /// `MappableTrackedObject.BodyNodePositionOffset` path in FrooxEngine. Otherwise it is the
     /// controller's tracking-space pose directly. `hand_position` / `hand_rotation` on
     /// [`VRControllerState`] are registration-time offsets (see
-    /// [`crate::xr::input::pose::bound_hand_pose_defaults`]), not tracking-space poses.
+    /// [`crate::xr::input::pose::hand_pose_defaults`]), not tracking-space poses.
     wrist_position: Vec3,
     /// Tracking-space wrist rotation to report on [`HandState::wrist_rotation`]. Composed the same
     /// way as [`Self::wrist_position`] and normalised.

--- a/crates/renderide/src/xr/input/openxr_actions.rs
+++ b/crates/renderide/src/xr/input/openxr_actions.rs
@@ -48,9 +48,9 @@ fn resolve_user_paths(instance: &xr::Instance) -> Result<UserPaths, xr::sys::Res
     })
 }
 
-/// Creates the four controller pose spaces (left/right grip, left/right aim) anchored at
+/// Creates the controller pose spaces (grip, aim, palm) anchored at
 /// [`openxr::Posef::IDENTITY`] for the lifetime of the session.
-fn create_grip_and_aim_spaces(
+fn create_pose_spaces(
     session: &xr::Session<xr::Vulkan>,
     actions: &OpenxrInputActions,
 ) -> Result<(xr::Space, xr::Space, xr::Space, xr::Space), xr::sys::Result> {
@@ -62,14 +62,13 @@ fn create_grip_and_aim_spaces(
             .right_grip_pose
             .create_space(session, xr::Path::NULL, xr::Posef::IDENTITY)?,
         actions
-            .left_aim_pose
+            .left_palm_ext_pose
             .create_space(session, xr::Path::NULL, xr::Posef::IDENTITY)?,
         actions
-            .right_aim_pose
+            .right_palm_ext_pose
             .create_space(session, xr::Path::NULL, xr::Posef::IDENTITY)?,
     ))
 }
-
 /// Container for everything [`super::openxr_input::OpenxrInput`] needs after setup.
 pub(super) struct OpenxrInputParts {
     /// OpenXR action set, kept alive for the session.
@@ -90,10 +89,10 @@ pub(super) struct OpenxrInputParts {
     pub(super) left_space: xr::Space,
     /// Right grip pose space.
     pub(super) right_space: xr::Space,
-    /// Left aim pose space.
-    pub(super) left_aim_space: xr::Space,
-    /// Right aim pose space.
-    pub(super) right_aim_space: xr::Space,
+    /// Left palm pose space.
+    pub(super) left_palm_ext_space: xr::Space,
+    /// Right palm pose space.
+    pub(super) right_palm_ext_space: xr::Space,
 }
 
 /// Manifest-driven end-to-end OpenXR input setup: action set, actions, suggested bindings, attach, spaces.
@@ -131,8 +130,8 @@ pub(super) fn create_openxr_input_parts(
 
     session.attach_action_sets(&[&action_set])?;
 
-    let (left_space, right_space, left_aim_space, right_aim_space) =
-        create_grip_and_aim_spaces(session, &actions)?;
+    let (left_space, right_space, left_palm_space, right_palm_space) =
+        create_pose_spaces(session, &actions)?;
 
     Ok(OpenxrInputParts {
         action_set,
@@ -144,7 +143,7 @@ pub(super) fn create_openxr_input_parts(
         right_profile_cache: AtomicU8::new(0),
         left_space,
         right_space,
-        left_aim_space,
-        right_aim_space,
+        left_palm_ext_space: left_palm_space,
+        right_palm_ext_space: right_palm_space,
     })
 }

--- a/crates/renderide/src/xr/input/openxr_actions/action_handles.rs
+++ b/crates/renderide/src/xr/input/openxr_actions/action_handles.rs
@@ -14,10 +14,10 @@ pub(in crate::xr::input) struct OpenxrInputActions {
     pub(in crate::xr::input) left_grip_pose: xr::Action<xr::Posef>,
     /// Right-hand tracked grip pose.
     pub(in crate::xr::input) right_grip_pose: xr::Action<xr::Posef>,
-    /// Left-hand aim pose (pointing ray origin).
-    pub(in crate::xr::input) left_aim_pose: xr::Action<xr::Posef>,
-    /// Right-hand aim pose.
-    pub(in crate::xr::input) right_aim_pose: xr::Action<xr::Posef>,
+    /// Left-hand palm_ext pose.
+    pub(in crate::xr::input) left_palm_ext_pose: xr::Action<xr::Posef>,
+    /// Right-hand palm_ext pose.
+    pub(in crate::xr::input) right_palm_ext_pose: xr::Action<xr::Posef>,
 
     /// Left trigger analog value, 0..=1.
     pub(in crate::xr::input) left_trigger: xr::Action<f32>,
@@ -188,8 +188,8 @@ pub(in crate::xr::input) fn build_actions(
     Ok(OpenxrInputActions {
         left_grip_pose: create_pose(action_set, manifest, "left_grip_pose")?,
         right_grip_pose: create_pose(action_set, manifest, "right_grip_pose")?,
-        left_aim_pose: create_pose(action_set, manifest, "left_aim_pose")?,
-        right_aim_pose: create_pose(action_set, manifest, "right_aim_pose")?,
+        left_palm_ext_pose: create_pose(action_set, manifest, "left_palm_ext_pose")?,
+        right_palm_ext_pose: create_pose(action_set, manifest, "right_palm_ext_pose")?,
 
         left_trigger: create_float(action_set, manifest, "left_trigger")?,
         right_trigger: create_float(action_set, manifest, "right_trigger")?,

--- a/crates/renderide/src/xr/input/openxr_input.rs
+++ b/crates/renderide/src/xr/input/openxr_input.rs
@@ -114,8 +114,8 @@ pub struct OpenxrInput {
     actions: OpenxrInputActions,
     left_space: xr::Space,
     right_space: xr::Space,
-    left_aim_space: xr::Space,
-    right_aim_space: xr::Space,
+    left_palm_ext_space: xr::Space,
+    right_palm_ext_space: xr::Space,
 }
 
 impl OpenxrInput {
@@ -145,8 +145,8 @@ impl OpenxrInput {
             actions: parts.actions,
             left_space: parts.left_space,
             right_space: parts.right_space,
-            left_aim_space: parts.left_aim_space,
-            right_aim_space: parts.right_aim_space,
+            left_palm_ext_space: parts.left_palm_ext_space,
+            right_palm_ext_space: parts.right_palm_ext_space,
         }
     }
 
@@ -293,12 +293,12 @@ impl OpenxrInput {
         session.sync_actions(&[xr::ActiveActionSet::new(&self.action_set)])?;
         let left_loc = self.left_space.locate(stage, predicted_time)?;
         let right_loc = self.right_space.locate(stage, predicted_time)?;
-        let left_aim_loc = self.left_aim_space.locate(stage, predicted_time)?;
-        let right_aim_loc = self.right_aim_space.locate(stage, predicted_time)?;
+        let left_palm_ext_loc = self.left_palm_ext_space.locate(stage, predicted_time)?;
+        let right_palm_ext_loc = self.right_palm_ext_space.locate(stage, predicted_time)?;
         let left_grip_pose = pose_from_location(&left_loc);
         let right_grip_pose = pose_from_location(&right_loc);
-        let left_aim_pose = pose_from_location(&left_aim_loc);
-        let right_aim_pose = pose_from_location(&right_aim_loc);
+        let left_palm_ext_pose = pose_from_location(&left_palm_ext_loc);
+        let right_palm_ext_pose = pose_from_location(&right_palm_ext_loc);
 
         let left_polled = self.poll_hand_action_states(session, Chirality::Left)?;
         let right_polled = self.poll_hand_action_states(session, Chirality::Right)?;
@@ -307,19 +307,27 @@ impl OpenxrInput {
         let right_profile = self.active_profile(session, self.right_user_path, Chirality::Right);
         log_profile_transition(Chirality::Left, left_profile);
         log_profile_transition(Chirality::Right, right_profile);
-        Self::log_grip_missing_aim_valid_throttled(Chirality::Left, left_grip_pose, left_aim_pose);
-        Self::log_grip_missing_aim_valid_throttled(
-            Chirality::Right,
-            right_grip_pose,
-            right_aim_pose,
+        Self::log_palm_ext_pose_missing_throttled(
+            Chirality::Left,
+            left_palm_ext_pose,
+            left_grip_pose,
         );
-        let left_frame =
-            resolve_controller_frame(left_profile, Chirality::Left, left_grip_pose, left_aim_pose);
+        Self::log_palm_ext_pose_missing_throttled(
+            Chirality::Right,
+            right_palm_ext_pose,
+            right_grip_pose,
+        );
+        let left_frame = resolve_controller_frame(
+            left_profile,
+            Chirality::Left,
+            left_grip_pose,
+            left_palm_ext_pose,
+        );
         let right_frame = resolve_controller_frame(
             right_profile,
             Chirality::Right,
             right_grip_pose,
-            right_aim_pose,
+            right_palm_ext_pose,
         );
         let left =
             ipc_vr_controller_from_polled(left_profile, Chirality::Left, left_frame, &left_polled);
@@ -335,12 +343,12 @@ impl OpenxrInput {
     /// Logs at most once every 300 frames per hand when the grip space is untracked but the aim space is valid.
     ///
     /// Confirms on-device that [`super::frame::resolve_controller_frame`] can use the aim fallback path.
-    fn log_grip_missing_aim_valid_throttled(
+    fn log_palm_ext_pose_missing_throttled(
         side: Chirality,
+        palm_ext_pose: Option<(Vec3, Quat)>,
         grip_pose: Option<(Vec3, Quat)>,
-        aim_pose: Option<(Vec3, Quat)>,
     ) {
-        if grip_pose.is_some() || aim_pose.is_none() {
+        if palm_ext_pose.is_some() || grip_pose.is_none() {
             return;
         }
         static LEFT: AtomicU32 = AtomicU32::new(0);
@@ -352,7 +360,7 @@ impl OpenxrInput {
         let n = slot.fetch_add(1, Ordering::Relaxed);
         if n % 300 == 0 {
             logger::debug!(
-                "OpenXR {side:?}: grip pose invalid or untracked but aim pose valid; resolving controller frame from aim for IPC"
+                "OpenXR {side:?}: grip surface pose invalid or untracked but grip pose valid; resolving controller frame from grip for IPC"
             );
         }
     }

--- a/crates/renderide/src/xr/input/pose.rs
+++ b/crates/renderide/src/xr/input/pose.rs
@@ -9,216 +9,8 @@ use glam::{EulerRot, Quat, Vec3};
 use openxr as xr;
 
 use crate::shared::Chirality;
-use crate::xr::session::openxr_tracking_pose_to_host;
 
 use super::profile::ActiveControllerProfile;
-
-/// Builds a quaternion with the same Y-X-Z composition order Unity's `Quaternion.Euler` uses,
-/// so per-profile rotation constants align with the host controller calibration data.
-pub(super) fn unity_euler_deg(x: f32, y: f32, z: f32) -> Quat {
-    Quat::from_rotation_y(y.to_radians())
-        * Quat::from_rotation_x(x.to_radians())
-        * Quat::from_rotation_z(z.to_radians())
-}
-
-/// Local OpenXR-space transform from standardized grip pose to SteamVR-style raw controller pose.
-#[derive(Clone, Copy)]
-pub(super) struct RawFromGripTransform {
-    rotation: Quat,
-    translation: Vec3,
-}
-
-impl RawFromGripTransform {
-    fn identity() -> Self {
-        Self {
-            rotation: Quat::IDENTITY,
-            translation: Vec3::ZERO,
-        }
-    }
-
-    fn from_grip_from_raw(rotation: Quat, translation: Vec3) -> Self {
-        let rotation = rotation.normalize();
-        let raw_from_grip_rotation = rotation.inverse();
-        Self {
-            rotation: raw_from_grip_rotation,
-            translation: raw_from_grip_rotation * -translation,
-        }
-    }
-
-    fn apply(self, position: Vec3, rotation: Quat) -> (Vec3, Quat) {
-        (
-            position + rotation * self.translation,
-            (rotation * self.rotation).normalize(),
-        )
-    }
-}
-
-/// Returns the local OpenXR-space transform from grip pose to SteamVR raw controller pose.
-pub(super) fn steamvr_raw_from_openxr_grip(
-    profile: ActiveControllerProfile,
-    side: Chirality,
-) -> RawFromGripTransform {
-    let (grip_from_raw_rotation, grip_from_raw_translation) = match (profile, side) {
-        (ActiveControllerProfile::Index, Chirality::Left) => (
-            Quat::from_euler(
-                EulerRot::XYZ,
-                15.392_f32.to_radians(),
-                -2.071_f32.to_radians(),
-                0.303_f32.to_radians(),
-            ),
-            Vec3::new(0.0, -0.015, 0.13),
-        ),
-        (ActiveControllerProfile::Index, Chirality::Right) => (
-            Quat::from_euler(
-                EulerRot::XYZ,
-                15.392_f32.to_radians(),
-                2.071_f32.to_radians(),
-                -0.303_f32.to_radians(),
-            ),
-            Vec3::new(0.0, -0.015, 0.13),
-        ),
-        (ActiveControllerProfile::Touch | ActiveControllerProfile::ViveFocus3, Chirality::Left) => {
-            (
-                Quat::from_euler(EulerRot::XYZ, 20.6_f32.to_radians(), 0.0, 0.0),
-                Vec3::new(0.007, -0.001_829_41, 0.101_948_2),
-            )
-        }
-        (
-            ActiveControllerProfile::Touch | ActiveControllerProfile::ViveFocus3,
-            Chirality::Right,
-        ) => (
-            Quat::from_euler(EulerRot::XYZ, 20.6_f32.to_radians(), 0.0, 0.0),
-            Vec3::new(-0.007, -0.001_829_41, 0.101_948_2),
-        ),
-        _ => return RawFromGripTransform::identity(),
-    };
-    RawFromGripTransform::from_grip_from_raw(grip_from_raw_rotation, grip_from_raw_translation)
-}
-
-/// Converts an OpenXR grip pose into the SteamVR raw controller pose expected by host IPC.
-///
-/// OpenXR `/input/grip/pose` is a standardized hand grip frame. SteamVR raw poses are device
-/// model frames, so controller models where those frames differ need a fixed local transform
-/// before host-specific controller corrections are applied.
-///
-/// Calibration is composed in OpenXR right-handed tracking space first. The calibrated raw pose is
-/// then converted into the host left-handed basis so controller frames and HMD frames enter
-/// FrooxEngine in the same tracking space.
-pub(super) fn openxr_grip_to_steamvr_raw(
-    profile: ActiveControllerProfile,
-    side: Chirality,
-    position: Vec3,
-    rotation: Quat,
-) -> (Vec3, Quat) {
-    let (raw_position, raw_rotation) =
-        steamvr_raw_from_openxr_grip(profile, side).apply(position, rotation);
-    openxr_tracking_pose_to_host(raw_position, raw_rotation)
-}
-
-/// Touch-only grip correction from `SteamVRDriver.UpdateController`: the real Oculus Touch is the
-/// one device SteamVR's raw pose was noticeably tilted and offset relative to where the host's
-/// hand anchor should sit.
-///
-/// OpenXR grip pose is not identical to SteamVR's raw pose, so a residual per-runtime offset is
-/// expected after this correction. Other controllers apply no grip correction in Unity and none
-/// here either.
-pub(super) fn touch_pose_correction(
-    side: Chirality,
-    position: Vec3,
-    rotation: Quat,
-) -> (Vec3, Quat) {
-    let rotation = rotation * Quat::from_rotation_x(45.0_f32.to_radians());
-    let offset = match side {
-        Chirality::Left => Vec3::new(-0.01, 0.04, 0.03),
-        Chirality::Right => Vec3::new(0.01, 0.04, 0.03),
-    };
-    (position - rotation * offset, rotation)
-}
-
-/// Default `hand_position` / `hand_rotation` on the IPC controller state types in
-/// [`crate::shared`] for bound-hand tracking (FrooxEngine `BodyNodePositionOffset` /
-/// `BodyNodeRotationOffset` on the hand device).
-///
-/// The host does not hardcode these: `VR_Manager` forwards IPC `handPosition` / `handRotation` into
-/// `MappableTrackedObject.Initialize` at registration.
-///
-/// `generic_fix = unity_euler_deg(90, 90, 90).inverse()` reproduces Unity's post-multiply
-/// `Quaternion.Inverse(Quaternion.Euler(90,90,90))`, applied only to Vive / Touch / Generic in
-/// that driver.
-///
-/// `hasBoundHand` is returned `true` for every profile. The host can otherwise prefer skeletal
-/// hand tracking for some profiles, but the renderer has no skeletal hand tracking, so the
-/// bound-hand defaults are always surfaced; Index / Cosmos / ViveFocus3 return identity so the
-/// hand visual sits at the grip rather than at a wrist offset that was never calibrated for them.
-pub(super) fn bound_hand_pose_defaults(
-    profile: ActiveControllerProfile,
-    side: Chirality,
-) -> (bool, Vec3, Quat) {
-    let generic_fix = unity_euler_deg(90.0, 90.0, 90.0).inverse();
-    let (position, rotation) = match (profile, side) {
-        (ActiveControllerProfile::Touch, Chirality::Left) => (
-            Vec3::new(-0.04, -0.025, -0.1),
-            unity_euler_deg(185.0, -95.0, -90.0) * generic_fix,
-        ),
-        (ActiveControllerProfile::Touch, Chirality::Right) => (
-            Vec3::new(0.04, -0.025, -0.1),
-            unity_euler_deg(5.0, -95.0, -90.0) * generic_fix,
-        ),
-        (
-            ActiveControllerProfile::Vive
-            | ActiveControllerProfile::Generic
-            | ActiveControllerProfile::Simple,
-            Chirality::Left,
-        ) => (
-            Vec3::new(-0.02, 0.0, -0.16),
-            unity_euler_deg(140.0, -90.0, -90.0) * generic_fix,
-        ),
-        (
-            ActiveControllerProfile::Vive
-            | ActiveControllerProfile::Generic
-            | ActiveControllerProfile::Simple,
-            Chirality::Right,
-        ) => (
-            Vec3::new(0.02, 0.0, -0.16),
-            unity_euler_deg(40.0, -90.0, -90.0) * generic_fix,
-        ),
-        (
-            ActiveControllerProfile::WindowsMr
-            | ActiveControllerProfile::HpReverbG2
-            | ActiveControllerProfile::Pico4
-            | ActiveControllerProfile::PicoNeo3,
-            Chirality::Left,
-        ) => (
-            Vec3::new(-0.028, 0.0, -0.18),
-            unity_euler_deg(30.0, 5.0, 100.0),
-        ),
-        (
-            ActiveControllerProfile::WindowsMr
-            | ActiveControllerProfile::HpReverbG2
-            | ActiveControllerProfile::Pico4
-            | ActiveControllerProfile::PicoNeo3,
-            Chirality::Right,
-        ) => (
-            Vec3::new(0.028, 0.0, -0.18),
-            unity_euler_deg(30.0, -5.0, -100.0),
-        ),
-        (
-            ActiveControllerProfile::Index
-            | ActiveControllerProfile::ViveCosmos
-            | ActiveControllerProfile::ViveFocus3,
-            _,
-        ) => (Vec3::ZERO, Quat::IDENTITY),
-    };
-    (true, position, rotation)
-}
-
-/// Derives a controller grip-style pose from an OpenXR aim pose by stepping back along the
-/// OpenXR forward axis to the approximate grip origin.
-pub(super) fn controller_pose_from_aim(position: Vec3, rotation: Quat) -> (Vec3, Quat) {
-    let rotation = rotation.normalize();
-    let tip_offset = Vec3::new(0.0, 0.0, -0.075);
-    (position - rotation * tip_offset, rotation)
-}
 
 /// Converts an [`xr::SpaceLocation`] into OpenXR tracking-space `(position, rotation)`.
 ///
@@ -246,11 +38,75 @@ pub(super) fn pose_from_location(location: &xr::SpaceLocation) -> Option<(Vec3, 
     })
 }
 
+/// Default `hand_position` / `hand_rotation` on the IPC controller state types in
+/// [`crate::shared`] for bound-hand tracking (FrooxEngine `BodyNodePositionOffset` /
+/// `BodyNodeRotationOffset` on the hand device).
+///
+/// These are currently hardcoded to match the OpenXR palm_ext pose.
+pub(super) fn hand_pose_defaults(side: Chirality) -> (Vec3, Quat) {
+    match side {
+        Chirality::Left => (
+            Vec3::new(0.0, 0.01, -0.08),
+            Quat::from_euler(
+                EulerRot::XYZ,
+                11.5f32.to_radians(),
+                0.5f32.to_radians(),
+                93.7f32.to_radians(),
+            ),
+        ),
+        Chirality::Right => (
+            Vec3::new(0.0, 0.01, -0.08),
+            Quat::from_euler(
+                EulerRot::XYZ,
+                11.5f32.to_radians(),
+                0.5f32.to_radians(),
+                -93.7f32.to_radians(),
+            ),
+        ),
+    }
+}
+
+/// Converts an OpenXR grip pose into a palm_ext pose using per-profile offsets.
+///
+/// Offsets can be derived using https://github.com/ValveSoftware/OpenXR-Canonical-Pose-Tool
+pub(super) fn grip_to_palm_ext_pose(
+    profile: ActiveControllerProfile,
+    side: Chirality,
+    grip_pose: (Vec3, Quat),
+) -> (Vec3, Quat) {
+    let (palm_ext_rot_offset, palm_ext_pos_offset) = match (profile, side) {
+        (ActiveControllerProfile::Index, Chirality::Left) => (
+            Quat::from_xyzw(-0.46, -0.02, -0.01, 0.89).normalize(),
+            Vec3::new(-0.015, 0.000, 0.001),
+        ),
+        (ActiveControllerProfile::Index, Chirality::Right) => (
+            Quat::from_xyzw(-0.46, 0.02, 0.01, 0.89).normalize(),
+            Vec3::new(0.015, 0.000, 0.001),
+        ),
+        // generic fallback
+        // for now these are based on index, but ideally they should be swapped out for touch controllers
+        // later as most controllers out there are heavily inspired by them.
+        (_, Chirality::Left) => (
+            Quat::from_xyzw(-0.46, -0.02, -0.01, 0.89).normalize(),
+            Vec3::new(-0.015, 0.000, 0.001),
+        ),
+        (_, Chirality::Right) => (
+            Quat::from_xyzw(-0.46, 0.02, 0.01, 0.89).normalize(),
+            Vec3::new(0.015, 0.000, 0.001),
+        ),
+    };
+
+    let (pos, rot) = grip_pose;
+
+    let surface_pos = pos + rot * palm_ext_pos_offset;
+    let surface_rot = rot * palm_ext_rot_offset;
+
+    (surface_pos, surface_rot)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    use crate::xr::session::openxr_tracking_pose_to_host;
 
     fn assert_vec3_near(actual: Vec3, expected: Vec3) {
         let delta = (actual - expected).length();
@@ -266,170 +122,6 @@ mod tests {
             (1.0 - dot) < 1e-4,
             "quat mismatch: actual={actual:?} expected={expected:?} dot={dot}"
         );
-    }
-
-    fn rotation_angle_from_identity(rotation: Quat) -> f32 {
-        2.0 * rotation.normalize().w.abs().clamp(-1.0, 1.0).acos()
-    }
-
-    #[test]
-    fn calibrated_raw_from_grip_transforms_match_profile_table() {
-        for (profile, side, grip_from_raw_rotation, grip_from_raw_translation) in [
-            (
-                ActiveControllerProfile::Index,
-                Chirality::Left,
-                Quat::from_euler(
-                    EulerRot::XYZ,
-                    15.392_f32.to_radians(),
-                    -2.071_f32.to_radians(),
-                    0.303_f32.to_radians(),
-                ),
-                Vec3::new(0.0, -0.015, 0.13),
-            ),
-            (
-                ActiveControllerProfile::Index,
-                Chirality::Right,
-                Quat::from_euler(
-                    EulerRot::XYZ,
-                    15.392_f32.to_radians(),
-                    2.071_f32.to_radians(),
-                    -0.303_f32.to_radians(),
-                ),
-                Vec3::new(0.0, -0.015, 0.13),
-            ),
-            (
-                ActiveControllerProfile::Touch,
-                Chirality::Left,
-                Quat::from_euler(EulerRot::XYZ, 20.6_f32.to_radians(), 0.0, 0.0),
-                Vec3::new(0.007, -0.001_829_41, 0.101_948_2),
-            ),
-            (
-                ActiveControllerProfile::Touch,
-                Chirality::Right,
-                Quat::from_euler(EulerRot::XYZ, 20.6_f32.to_radians(), 0.0, 0.0),
-                Vec3::new(-0.007, -0.001_829_41, 0.101_948_2),
-            ),
-            (
-                ActiveControllerProfile::ViveFocus3,
-                Chirality::Left,
-                Quat::from_euler(EulerRot::XYZ, 20.6_f32.to_radians(), 0.0, 0.0),
-                Vec3::new(0.007, -0.001_829_41, 0.101_948_2),
-            ),
-            (
-                ActiveControllerProfile::ViveFocus3,
-                Chirality::Right,
-                Quat::from_euler(EulerRot::XYZ, 20.6_f32.to_radians(), 0.0, 0.0),
-                Vec3::new(-0.007, -0.001_829_41, 0.101_948_2),
-            ),
-        ] {
-            let actual = steamvr_raw_from_openxr_grip(profile, side);
-            let expected = RawFromGripTransform::from_grip_from_raw(
-                grip_from_raw_rotation,
-                grip_from_raw_translation,
-            );
-            assert_vec3_near(actual.translation, expected.translation);
-            assert_quat_near(actual.rotation, expected.rotation);
-        }
-    }
-
-    #[test]
-    fn identity_calibration_profiles_emit_openxr_grip_unchanged_before_host_conversion() {
-        let grip_position = Vec3::new(0.25, 1.4, -0.35);
-        let grip_rotation = (Quat::from_rotation_y(0.6) * Quat::from_rotation_x(-0.2)).normalize();
-
-        for profile in [
-            ActiveControllerProfile::Vive,
-            ActiveControllerProfile::WindowsMr,
-            ActiveControllerProfile::HpReverbG2,
-            ActiveControllerProfile::Pico4,
-            ActiveControllerProfile::PicoNeo3,
-            ActiveControllerProfile::ViveCosmos,
-            ActiveControllerProfile::Generic,
-            ActiveControllerProfile::Simple,
-        ] {
-            for side in [Chirality::Left, Chirality::Right] {
-                let (position, rotation) =
-                    steamvr_raw_from_openxr_grip(profile, side).apply(grip_position, grip_rotation);
-                assert_vec3_near(position, grip_position);
-                assert_quat_near(rotation, grip_rotation);
-            }
-        }
-    }
-
-    #[test]
-    fn identity_calibration_profiles_convert_result_to_host_tracking_space() {
-        let grip_position = Vec3::new(0.25, 1.4, -0.35);
-        let grip_rotation = (Quat::from_rotation_y(0.6) * Quat::from_rotation_x(-0.2)).normalize();
-        let (expected_position, expected_rotation) =
-            openxr_tracking_pose_to_host(grip_position, grip_rotation);
-
-        let (position, rotation) = openxr_grip_to_steamvr_raw(
-            ActiveControllerProfile::Vive,
-            Chirality::Left,
-            grip_position,
-            grip_rotation,
-        );
-
-        assert_vec3_near(position, expected_position);
-        assert_quat_near(rotation, expected_rotation);
-    }
-
-    #[test]
-    fn raw_pose_offset_magnitudes_match_supported_profiles() {
-        for (profile, expected_translation, angle_min, angle_max) in [
-            (ActiveControllerProfile::Index, 0.130_86, 0.26, 0.28),
-            (ActiveControllerProfile::Touch, 0.102_2, 0.35, 0.37),
-            (ActiveControllerProfile::ViveFocus3, 0.102_2, 0.35, 0.37),
-        ] {
-            for side in [Chirality::Left, Chirality::Right] {
-                let (position, rotation) =
-                    steamvr_raw_from_openxr_grip(profile, side).apply(Vec3::ZERO, Quat::IDENTITY);
-                assert!(
-                    (position.length() - expected_translation).abs() < 1e-4,
-                    "{profile:?} {side:?}: position offset {position:?}",
-                );
-                let angle = rotation_angle_from_identity(rotation);
-                assert!(
-                    (angle_min..=angle_max).contains(&angle),
-                    "{profile:?} {side:?}: rotation angle {angle}",
-                );
-            }
-        }
-    }
-
-    #[test]
-    fn raw_pose_offsets_mirror_across_hands() {
-        for profile in [
-            ActiveControllerProfile::Index,
-            ActiveControllerProfile::Touch,
-            ActiveControllerProfile::ViveFocus3,
-        ] {
-            let (left_position, left_rotation) =
-                steamvr_raw_from_openxr_grip(profile, Chirality::Left)
-                    .apply(Vec3::ZERO, Quat::IDENTITY);
-            let (right_position, right_rotation) =
-                steamvr_raw_from_openxr_grip(profile, Chirality::Right)
-                    .apply(Vec3::ZERO, Quat::IDENTITY);
-
-            assert!(
-                (left_position.x + right_position.x).abs() < 1e-4,
-                "{profile:?}: position X should mirror: left={left_position:?}, right={right_position:?}",
-            );
-            assert!(
-                (left_position.y - right_position.y).abs() < 1e-4,
-                "{profile:?}: position Y should match: left={left_position:?}, right={right_position:?}",
-            );
-            assert!(
-                (left_position.z - right_position.z).abs() < 1e-4,
-                "{profile:?}: position Z should match: left={left_position:?}, right={right_position:?}",
-            );
-            let left_angle = rotation_angle_from_identity(left_rotation);
-            let right_angle = rotation_angle_from_identity(right_rotation);
-            assert!(
-                (left_angle - right_angle).abs() < 1e-4,
-                "{profile:?}: rotation angle should match: left={left_angle}, right={right_angle}",
-            );
-        }
     }
 
     #[test]
@@ -457,128 +149,5 @@ mod tests {
 
         assert_vec3_near(position, Vec3::new(1.0, 2.0, -3.0));
         assert_quat_near(rotation, expected_rotation);
-    }
-
-    /// Bound-hand rotations for profiles Unity post-multiplies with `generic_fix` must have a
-    /// palm normal pointing inward (+/-X toward the other hand), not forward or down. Guards
-    /// against accidentally dropping `generic_fix`.
-    #[test]
-    fn neutral_grip_palm_faces_inward_not_forward_generic() {
-        for (side, expected_x_sign) in [(Chirality::Left, -1.0_f32), (Chirality::Right, 1.0_f32)] {
-            let (_, _, hand_rot) = bound_hand_pose_defaults(ActiveControllerProfile::Generic, side);
-            let palm_normal = hand_rot * Vec3::Y;
-            assert!(
-                palm_normal.x * expected_x_sign > 0.5,
-                "{side:?}: palm normal {palm_normal:?} should have significant inward X component \
-                 (expected sign {expected_x_sign}), got X={}",
-                palm_normal.x,
-            );
-            assert!(
-                palm_normal.z.abs() < 0.5,
-                "{side:?}: palm normal {palm_normal:?} should not point strongly forward/back",
-            );
-        }
-    }
-
-    #[test]
-    fn neutral_grip_palm_faces_inward_not_forward_touch() {
-        for (side, expected_x_sign) in [(Chirality::Left, -1.0_f32), (Chirality::Right, 1.0_f32)] {
-            let (_, _, hand_rot) = bound_hand_pose_defaults(ActiveControllerProfile::Touch, side);
-            let palm_normal = hand_rot * Vec3::Y;
-            assert!(
-                palm_normal.x * expected_x_sign > 0.3,
-                "{side:?}: palm normal {palm_normal:?} should have inward X component \
-                 (expected sign {expected_x_sign}), got X={}",
-                palm_normal.x,
-            );
-        }
-    }
-
-    #[test]
-    fn bound_hand_chirality_mirrors_x_component() {
-        for profile in [
-            ActiveControllerProfile::Generic,
-            ActiveControllerProfile::Touch,
-            ActiveControllerProfile::Vive,
-            ActiveControllerProfile::WindowsMr,
-            ActiveControllerProfile::HpReverbG2,
-            ActiveControllerProfile::Pico4,
-            ActiveControllerProfile::PicoNeo3,
-        ] {
-            let (_, pos_l, rot_l) = bound_hand_pose_defaults(profile, Chirality::Left);
-            let (_, pos_r, rot_r) = bound_hand_pose_defaults(profile, Chirality::Right);
-            assert!(
-                (pos_l.x + pos_r.x).abs() < 1e-4,
-                "{profile:?}: position X should be mirrored: left={}, right={}",
-                pos_l.x,
-                pos_r.x,
-            );
-            let palm_l = rot_l * Vec3::Y;
-            let palm_r = rot_r * Vec3::Y;
-            assert!(
-                (palm_l.x + palm_r.x).abs() < 0.15,
-                "{profile:?}: palm normal X should be approximately mirrored: left={palm_l:?}, right={palm_r:?}",
-            );
-        }
-    }
-
-    /// Profiles without calibrated hand offsets (Index, ViveCosmos, ViveFocus3) return identity
-    /// pose so the hand visual sits at the grip origin instead of at a wrong wrist offset.
-    #[test]
-    fn identity_profiles_have_zero_offset_and_identity_rotation() {
-        for profile in [
-            ActiveControllerProfile::Index,
-            ActiveControllerProfile::ViveCosmos,
-            ActiveControllerProfile::ViveFocus3,
-        ] {
-            for side in [Chirality::Left, Chirality::Right] {
-                let (has, pos, rot) = bound_hand_pose_defaults(profile, side);
-                assert!(has, "{profile:?} {side:?}: has_bound_hand must be true");
-                assert!(
-                    pos.length() < 1e-6,
-                    "{profile:?} {side:?}: expected zero position, got {pos:?}",
-                );
-                let dot = rot.normalize().dot(Quat::IDENTITY).abs();
-                assert!(
-                    (1.0 - dot) < 1e-6,
-                    "{profile:?} {side:?}: expected identity rotation, got {rot:?}",
-                );
-            }
-        }
-    }
-
-    /// Pico4 / PicoNeo3 / HpReverbG2 share the Windows MR bound-hand values.
-    #[test]
-    fn pico_and_reverb_share_windowsmr_defaults() {
-        let reference = [
-            bound_hand_pose_defaults(ActiveControllerProfile::WindowsMr, Chirality::Left),
-            bound_hand_pose_defaults(ActiveControllerProfile::WindowsMr, Chirality::Right),
-        ];
-        for profile in [
-            ActiveControllerProfile::HpReverbG2,
-            ActiveControllerProfile::Pico4,
-            ActiveControllerProfile::PicoNeo3,
-        ] {
-            for (side, expected) in [
-                (Chirality::Left, reference[0]),
-                (Chirality::Right, reference[1]),
-            ] {
-                let got = bound_hand_pose_defaults(profile, side);
-                assert_eq!(got.0, expected.0, "{profile:?} {side:?}");
-                assert!(
-                    (got.1 - expected.1).length() < 1e-6,
-                    "{profile:?} {side:?}: position {:?} vs {:?}",
-                    got.1,
-                    expected.1,
-                );
-                let dot = got.2.normalize().dot(expected.2.normalize()).abs();
-                assert!(
-                    (1.0 - dot) < 1e-6,
-                    "{profile:?} {side:?}: rotation {:?} vs {:?}",
-                    got.2,
-                    expected.2,
-                );
-            }
-        }
     }
 }


### PR DESCRIPTION
Uses the XR_EXT_palm_pose extension to position the hand, or fallback offsets from the grip pose if not available.

Currently there's only an offset for index knuckles, more would need to be added using https://github.com/ValveSoftware/OpenXR-Canonical-Pose-Tool, though the generic one might be relatively close already.