### PR TITLE
Rectify reflection probe background color behavior

### DIFF
--- a/crates/renderide/shaders/modules/skybox/evaluator.wgsl
+++ b/crates/renderide/shaders/modules/skybox/evaluator.wgsl
@@ -11,6 +11,7 @@ struct SkyboxEvaluatorParams {
     sample_size: u32,
     mode: u32,
     gradient_count: u32,
+    _pad: u32,
     color_a: vec4<f32>,
     color_b: vec4<f32>,
     direction: vec4<f32>,

--- a/crates/renderide/src/graph_inputs.rs
+++ b/crates/renderide/src/graph_inputs.rs
@@ -46,7 +46,6 @@ impl FrameViewClear {
     }
 
     /// Color clear mode with the supplied linear RGBA background.
-    #[cfg(test)]
     pub fn color(color: glam::Vec4) -> Self {
         Self {
             mode: CameraClearMode::Color,

--- a/crates/renderide/src/reflection_probes/sh2_math.rs
+++ b/crates/renderide/src/reflection_probes/sh2_math.rs
@@ -12,16 +12,6 @@ const PROJECTION360_DEFAULT_FOV: [f32; 4] = [std::f32::consts::TAU, std::f32::co
 #[cfg(test)]
 const DEFAULT_MAIN_TEX_ST: [f32; 4] = [1.0, 1.0, 0.0, 0.0];
 
-/// Bit pattern for a packed float4.
-pub(super) fn f32x4_bits(v: [f32; 4]) -> [u32; 4] {
-    [
-        v[0].to_bits(),
-        v[1].to_bits(),
-        v[2].to_bits(),
-        v[3].to_bits(),
-    ]
-}
-
 /// Analytic raw SH2 coefficients for a constant radiance color.
 pub(super) fn constant_color_sh2(color: Vec3) -> RenderSH2 {
     let c = color * (4.0 * std::f32::consts::PI * SH_C0);

--- a/crates/renderide/src/reflection_probes/sh2_system.rs
+++ b/crates/renderide/src/reflection_probes/sh2_system.rs
@@ -255,7 +255,13 @@ fn sh2_source_from_ibl_source(
                 storage_v_inverted: src.storage_v_inverted,
             };
             (
-                Sh2SourceKey::cubemap(render_space_id, identity, src.asset_id, residency),
+                Sh2SourceKey::cubemap(
+                    render_space_id,
+                    identity,
+                    src.asset_id,
+                    residency,
+                    src.clear_color,
+                ),
                 Sh2ResolvedSource::Gpu(GpuSh2Source::Cubemap {
                     asset_id: src.asset_id,
                     storage_v_inverted: src.storage_v_inverted,
@@ -281,6 +287,7 @@ fn sh2_source_from_ibl_source(
                 generation: src.generation,
                 size: src.face_size,
                 sample_size: DEFAULT_SAMPLE_SIZE,
+                clear_color_key: src.clear_color.map(|c| c.to_array().map(|f| f.to_bits())),
             },
             Sh2ResolvedSource::Gpu(GpuSh2Source::RuntimeCubemap {
                 clear_color: src.clear_color,

--- a/crates/renderide/src/reflection_probes/sh2_system.rs
+++ b/crates/renderide/src/reflection_probes/sh2_system.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 use glam::Vec3;
 use hashbrown::{HashMap, HashSet};
 
-use super::sh2_math::{constant_color_sh2, f32x4_bits};
+use super::sh2_math::constant_color_sh2;
 use super::source_resolution::Sh2ResolvedSource;
 use crate::backend::AssetTransferQueue;
 use crate::gpu::GpuContext;
@@ -259,13 +259,14 @@ fn sh2_source_from_ibl_source(
                 Sh2ResolvedSource::Gpu(GpuSh2Source::Cubemap {
                     asset_id: src.asset_id,
                     storage_v_inverted: src.storage_v_inverted,
+                    clear_color: src.clear_color,
                 }),
             )
         }
         SkyboxIblSource::SolidColor(src) => (
             Sh2SourceKey::ConstantColor {
                 render_space_id,
-                color_bits: f32x4_bits(src.color),
+                color_bits: src.color.map(|f| f.to_bits()),
             },
             Sh2ResolvedSource::Cpu(Box::new(constant_color_sh2(Vec3::new(
                 src.color[0],
@@ -282,6 +283,7 @@ fn sh2_source_from_ibl_source(
                 sample_size: DEFAULT_SAMPLE_SIZE,
             },
             Sh2ResolvedSource::Gpu(GpuSh2Source::RuntimeCubemap {
+                clear_color: src.clear_color,
                 texture: src.texture.clone(),
                 view: src.view.clone(),
             }),

--- a/crates/renderide/src/reflection_probes/sh2_system/gpu_source.rs
+++ b/crates/renderide/src/reflection_probes/sh2_system/gpu_source.rs
@@ -2,6 +2,8 @@
 
 use std::sync::Arc;
 
+use glam::Vec4;
+
 /// GPU-projected source payload queued for scheduling.
 #[derive(Clone, Debug)]
 pub(in crate::reflection_probes) enum GpuSh2Source {
@@ -11,6 +13,8 @@ pub(in crate::reflection_probes) enum GpuSh2Source {
         asset_id: i32,
         /// Source cubemap storage orientation.
         storage_v_inverted: bool,
+        /// Clear color to use instead of the actual skybox
+        clear_color: Option<Vec4>,
     },
     /// Renderer-captured OnChanges cubemap.
     RuntimeCubemap {
@@ -18,5 +22,7 @@ pub(in crate::reflection_probes) enum GpuSh2Source {
         texture: Arc<wgpu::Texture>,
         /// Cube view sampled by the SH2 projection shader.
         view: Arc<wgpu::TextureView>,
+        /// Clear color to use instead of the actual skybox
+        clear_color: Option<Vec4>,
     },
 }

--- a/crates/renderide/src/reflection_probes/sh2_system/scheduling.rs
+++ b/crates/renderide/src/reflection_probes/sh2_system/scheduling.rs
@@ -2,6 +2,8 @@
 
 use std::sync::Arc;
 
+use glam::Vec4;
+
 use super::super::projection_pipeline::{
     ProjectionBinding, ProjectionPipeline, ProjectionPipelineKind, encode_projection_job,
 };
@@ -13,6 +15,7 @@ use crate::backend::AssetTransferQueue;
 use crate::gpu::GpuContext;
 use crate::profiling;
 use crate::skybox::params::storage_v_inverted_flag;
+use crate::skybox::specular::solid_color_params;
 
 /// Maximum pending GPU jobs kept alive at once.
 const MAX_IN_FLIGHT_JOBS: usize = 6;
@@ -92,11 +95,23 @@ impl ReflectionProbeSh2System {
             GpuSh2Source::Cubemap {
                 asset_id,
                 storage_v_inverted,
+                clear_color,
             } => self
-                .schedule_cubemap_source(gpu, assets, key, asset_id, storage_v_inverted, pipeline)
+                .schedule_cubemap_source(
+                    gpu,
+                    assets,
+                    key,
+                    asset_id,
+                    &cubemap_projection_params(clear_color, storage_v_inverted),
+                    pipeline,
+                )
                 .map(ScheduleSourceOutcome::Submitted),
-            GpuSh2Source::RuntimeCubemap { texture, view } => self
-                .schedule_runtime_cubemap_source(gpu, key, texture, view, pipeline)
+            GpuSh2Source::RuntimeCubemap {
+                texture,
+                view,
+                clear_color,
+            } => self
+                .schedule_runtime_cubemap_source(gpu, key, texture, view, clear_color, pipeline)
                 .map(ScheduleSourceOutcome::Submitted),
         }
     }
@@ -107,7 +122,7 @@ impl ReflectionProbeSh2System {
         assets: &AssetTransferQueue,
         key: Sh2SourceKey,
         asset_id: i32,
-        storage_v_inverted: bool,
+        params: &Sh2ProjectParams,
         pipeline: &ProjectionPipeline,
     ) -> Result<SubmittedGpuSh2Job, String> {
         profiling::scope!("reflection_probe_sh2::schedule_cubemap");
@@ -119,7 +134,6 @@ impl ReflectionProbeSh2System {
         let sampler = sh2_cubemap_sampler(gpu.device(), "SH2 cubemap sampler");
         let view = tex.view.clone();
         let submit_done_tx = self.readback_jobs.submit_done_sender();
-        let params = cubemap_projection_params(storage_v_inverted);
         encode_projection_job(
             gpu,
             key,
@@ -128,7 +142,7 @@ impl ReflectionProbeSh2System {
                 ProjectionBinding::TextureView(view.as_ref()),
                 ProjectionBinding::Sampler(&sampler),
             ],
-            &params,
+            params,
             &submit_done_tx,
             "reflection_probe_sh2::project_cubemap",
         )
@@ -140,6 +154,7 @@ impl ReflectionProbeSh2System {
         key: Sh2SourceKey,
         texture: Arc<wgpu::Texture>,
         view: Arc<wgpu::TextureView>,
+        clear_color: Option<Vec4>,
         pipeline: &ProjectionPipeline,
     ) -> Result<SubmittedGpuSh2Job, String> {
         profiling::scope!("reflection_probe_sh2::schedule_runtime_cubemap");
@@ -153,7 +168,7 @@ impl ReflectionProbeSh2System {
                 ProjectionBinding::TextureView(view.as_ref()),
                 ProjectionBinding::Sampler(&sampler),
             ],
-            &Sh2ProjectParams::empty(SkyParamMode::Procedural),
+            &projection_params(clear_color),
             &submit_done_tx,
             "reflection_probe_sh2::project_runtime_cubemap",
         )?;
@@ -183,8 +198,18 @@ fn sh2_cubemap_sampler(device: &wgpu::Device, label: &'static str) -> wgpu::Samp
     })
 }
 
-fn cubemap_projection_params(storage_v_inverted: bool) -> Sh2ProjectParams {
-    let mut params = Sh2ProjectParams::empty(SkyParamMode::Procedural);
+fn projection_params(clear_color: Option<Vec4>) -> Sh2ProjectParams {
+    match clear_color {
+        Some(color) => solid_color_params(color.to_array()),
+        None => Sh2ProjectParams::empty(SkyParamMode::Procedural),
+    }
+}
+
+fn cubemap_projection_params(
+    clear_color: Option<Vec4>,
+    storage_v_inverted: bool,
+) -> Sh2ProjectParams {
+    let mut params = projection_params(clear_color);
     params.scalars[0] = storage_v_inverted_flag(storage_v_inverted);
     params
 }

--- a/crates/renderide/src/reflection_probes/sh2_system/source_keys.rs
+++ b/crates/renderide/src/reflection_probes/sh2_system/source_keys.rs
@@ -1,5 +1,6 @@
 //! Source-key types, projection parameter aliases, and shared constants.
 
+use glam::Vec4;
 use hashbrown::HashSet;
 
 use crate::scene::RenderSpaceId;
@@ -52,6 +53,8 @@ pub(in crate::reflection_probes) enum Sh2SourceKey {
         storage_v_inverted: bool,
         /// Projection sample grid edge per cube face.
         sample_size: u32,
+        /// Clear color to use instead of the actual skybox, converted as bits for comparison
+        clear_color_key: Option<[u32; 4]>,
     },
     /// Renderer-captured dynamic cubemap source.
     RuntimeCubemap {
@@ -65,6 +68,8 @@ pub(in crate::reflection_probes) enum Sh2SourceKey {
         size: u32,
         /// Projection sample grid edge per cube face.
         sample_size: u32,
+        /// Clear color to use instead of the actual skybox, converted as bits for comparison
+        clear_color_key: Option<[u32; 4]>,
     },
 }
 
@@ -75,6 +80,7 @@ impl Sh2SourceKey {
         material: CubemapSourceMaterialIdentity,
         asset_id: i32,
         residency: CubemapResidency,
+        clear_color: Option<Vec4>,
     ) -> Self {
         Self::Cubemap {
             render_space_id,
@@ -88,6 +94,7 @@ impl Sh2SourceKey {
             content_generation: residency.content_generation,
             storage_v_inverted: residency.storage_v_inverted,
             sample_size: DEFAULT_SAMPLE_SIZE,
+            clear_color_key: clear_color.map(|c| c.to_array().map(|f| f.to_bits())),
         }
     }
 

--- a/crates/renderide/src/reflection_probes/sh2_system/tests.rs
+++ b/crates/renderide/src/reflection_probes/sh2_system/tests.rs
@@ -92,5 +92,6 @@ fn cubemap_key_with_storage(
         content_generation: 1,
         storage_v_inverted,
         sample_size: DEFAULT_SAMPLE_SIZE,
+        clear_color_key: None,
     }
 }

--- a/crates/renderide/src/reflection_probes/source_resolution.rs
+++ b/crates/renderide/src/reflection_probes/source_resolution.rs
@@ -59,6 +59,7 @@ pub(super) fn resolve_task_source(
         }
         let asset_id = state.cubemap_asset_id;
         let identity = CubemapSourceMaterialIdentity::DIRECT_PROBE;
+        let clear_color = probe_clear_color(probe.state);
         let Some(cubemap) = assets.cubemap_pool().get(asset_id) else {
             return Some((
                 Sh2SourceKey::cubemap(
@@ -66,6 +67,7 @@ pub(super) fn resolve_task_source(
                     identity,
                     asset_id,
                     CubemapResidency::default(),
+                    clear_color,
                 ),
                 Sh2ResolvedSource::Postpone,
             ));
@@ -75,6 +77,7 @@ pub(super) fn resolve_task_source(
             identity,
             asset_id,
             cubemap_residency_from_pool(cubemap),
+            clear_color,
         );
         if cubemap.mip_levels_resident == 0 {
             return Some((key, Sh2ResolvedSource::Postpone));
@@ -84,7 +87,7 @@ pub(super) fn resolve_task_source(
             Sh2ResolvedSource::Gpu(GpuSh2Source::Cubemap {
                 asset_id,
                 storage_v_inverted: cubemap.storage_v_inverted,
-                clear_color: probe_clear_color(probe.state),
+                clear_color,
             }),
         ));
     }
@@ -105,6 +108,7 @@ fn resolve_runtime_capture_source(
         space_id: RenderSpaceId(render_space_id),
         renderable_index,
     };
+    let clear_color = probe_clear_color(probe.state);
     let Some(capture) = captures.get(key) else {
         return Some((
             Sh2SourceKey::RuntimeCubemap {
@@ -113,6 +117,7 @@ fn resolve_runtime_capture_source(
                 generation: 0,
                 size: 0,
                 sample_size: DEFAULT_SAMPLE_SIZE,
+                clear_color_key: clear_color.map(|c| c.to_array().map(|f| f.to_bits())),
             },
             Sh2ResolvedSource::Postpone,
         ));
@@ -123,13 +128,14 @@ fn resolve_runtime_capture_source(
         generation: capture.generation,
         size: capture.face_size,
         sample_size: DEFAULT_SAMPLE_SIZE,
+        clear_color_key: clear_color.map(|c| c.to_array().map(|f| f.to_bits())),
     };
     Some((
         key,
         Sh2ResolvedSource::Gpu(GpuSh2Source::RuntimeCubemap {
             texture: capture.texture.clone(),
             view: capture.view.clone(),
-            clear_color: probe_clear_color(probe.state),
+            clear_color,
         }),
     ))
 }
@@ -181,6 +187,7 @@ mod tests {
                 generation: 0,
                 size: 0,
                 sample_size: DEFAULT_SAMPLE_SIZE,
+                clear_color_key: None,
             }
         );
         assert!(matches!(source, Sh2ResolvedSource::Postpone));

--- a/crates/renderide/src/reflection_probes/source_resolution.rs
+++ b/crates/renderide/src/reflection_probes/source_resolution.rs
@@ -10,8 +10,10 @@ use super::{
 use crate::reflection_probes::specular::{
     RuntimeReflectionProbeCaptureKey, RuntimeReflectionProbeCaptureStore,
 };
-use crate::scene::{RenderSpaceId, SceneCoordinator};
-use crate::shared::{ReflectionProbeClear, ReflectionProbeType, RenderSH2};
+use crate::scene::{
+    ReflectionProbeEntry, RenderSpaceId, SceneCoordinator, reflection_probe_solid_color,
+};
+use crate::shared::{ReflectionProbeClear, ReflectionProbeState, ReflectionProbeType, RenderSH2};
 
 /// Either a synchronous CPU result or a GPU source to project.
 pub(super) enum Sh2ResolvedSource {
@@ -39,18 +41,18 @@ pub(super) fn resolve_task_source(
         .reflection_probes()
         .get(task.reflection_probe_renderable_index as usize)?;
     let state = probe.state;
-    if state.clear_flags == ReflectionProbeClear::Color {
+
+    if reflection_probe_solid_color(state) {
         let color = state.background_color * state.intensity.max(0.0);
         let key = Sh2SourceKey::ConstantColor {
             render_space_id,
-            color_bits: vec4_bits(color),
+            color_bits: color.to_array().map(|f| f.to_bits()),
         };
         return Some((
             key,
             Sh2ResolvedSource::Cpu(Box::new(constant_color_sh2(color.truncate()))),
         ));
     }
-
     if state.r#type == ReflectionProbeType::Baked {
         if state.cubemap_asset_id < 0 {
             return None;
@@ -82,21 +84,23 @@ pub(super) fn resolve_task_source(
             Sh2ResolvedSource::Gpu(GpuSh2Source::Cubemap {
                 asset_id,
                 storage_v_inverted: cubemap.storage_v_inverted,
+                clear_color: probe_clear_color(probe.state),
             }),
         ));
     }
 
     if state.r#type == ReflectionProbeType::OnChanges {
-        return resolve_runtime_capture_source(render_space_id, probe.renderable_index, captures);
+        return resolve_runtime_capture_source(render_space_id, probe, captures);
     }
     None
 }
 
 fn resolve_runtime_capture_source(
     render_space_id: i32,
-    renderable_index: i32,
+    probe: &ReflectionProbeEntry,
     captures: &RuntimeReflectionProbeCaptureStore,
 ) -> Option<(Sh2SourceKey, Sh2ResolvedSource)> {
+    let renderable_index = probe.renderable_index;
     let key = RuntimeReflectionProbeCaptureKey {
         space_id: RenderSpaceId(render_space_id),
         renderable_index,
@@ -125,6 +129,7 @@ fn resolve_runtime_capture_source(
         Sh2ResolvedSource::Gpu(GpuSh2Source::RuntimeCubemap {
             texture: capture.texture.clone(),
             view: capture.view.clone(),
+            clear_color: probe_clear_color(probe.state),
         }),
     ))
 }
@@ -141,9 +146,11 @@ fn cubemap_residency_from_pool(
     }
 }
 
-/// Bit pattern for a `Vec4`.
-fn vec4_bits(v: Vec4) -> [u32; 4] {
-    [v.x.to_bits(), v.y.to_bits(), v.z.to_bits(), v.w.to_bits()]
+pub fn probe_clear_color(state: ReflectionProbeState) -> Option<Vec4> {
+    match state.clear_flags {
+        ReflectionProbeClear::Skybox => None,
+        ReflectionProbeClear::Color => Some(state.background_color),
+    }
 }
 
 #[cfg(test)]
@@ -151,20 +158,19 @@ mod tests {
     use super::*;
 
     #[test]
-    fn vec4_bits_preserves_exact_float_bit_patterns() {
-        let bits = vec4_bits(Vec4::new(0.0, -0.0, f32::INFINITY, f32::NAN));
-
-        assert_eq!(bits[0], 0.0f32.to_bits());
-        assert_eq!(bits[1], (-0.0f32).to_bits());
-        assert_eq!(bits[2], f32::INFINITY.to_bits());
-        assert_eq!(bits[3], f32::NAN.to_bits());
-    }
-
-    #[test]
     fn missing_runtime_capture_postpones_onchanges_probe() {
         let captures = RuntimeReflectionProbeCaptureStore::default();
 
-        let (key, source) = resolve_runtime_capture_source(7, 3, &captures)
+        let probe = ReflectionProbeEntry {
+            renderable_index: 3,
+            transform_id: 12,
+            state: ReflectionProbeState {
+                clear_flags: ReflectionProbeClear::Skybox,
+                ..Default::default()
+            },
+        };
+
+        let (key, source) = resolve_runtime_capture_source(7, &probe, &captures)
             .expect("missing captures should return a stable postponed key");
 
         assert_eq!(

--- a/crates/renderide/src/reflection_probes/specular/selection.rs
+++ b/crates/renderide/src/reflection_probes/specular/selection.rs
@@ -146,14 +146,13 @@ impl ReflectionProbeSpatialIndex {
                         probe_volume: probe.volume,
                         center_distance_sq: (probe.center - object_center).length_squared(),
                         renderable_index: probe.renderable_index,
-                        skybox: probe.skybox,
                     };
-                    if probe.skybox {
-                        if aabb_contains(probe.aabb_min, probe.aabb_max, object_min, object_max) {
-                            fallback = fallback
-                                .filter(|&best| score_better(best, score))
-                                .or(Some(score));
-                        }
+                    if probe.skybox
+                        && aabb_contains(probe.aabb_min, probe.aabb_max, object_min, object_max)
+                    {
+                        fallback = fallback
+                            .filter(|&best| score_better(best, score))
+                            .or(Some(score));
                         continue;
                     }
                     insert_probe_score(&mut top, score);
@@ -219,7 +218,6 @@ struct ProbeScore {
     probe_volume: f32,
     center_distance_sq: f32,
     renderable_index: i32,
-    skybox: bool,
 }
 
 fn insert_probe_score(top: &mut Vec<ProbeScore>, score: ProbeScore) {
@@ -248,7 +246,6 @@ fn score_better(a: ProbeScore, b: ProbeScore) -> bool {
     a.importance
         .cmp(&b.importance)
         .reverse()
-        .then_with(|| a.skybox.cmp(&b.skybox))
         .then_with(|| {
             a.influence_intersection
                 .total_cmp(&b.influence_intersection)
@@ -615,7 +612,8 @@ mod tests {
 
         let selection = index.select((Vec3::new(1.25, -0.25, -0.25), Vec3::new(1.5, 0.25, 0.25)));
 
-        assert_eq!(selection, ReflectionProbeDrawSelection::default());
+        // Still used as local, considering it has a non zero intersection
+        assert_eq!(selection, expected_selection(0, [3, 0, 0, 0], 0b0000));
     }
 
     #[test]
@@ -673,7 +671,6 @@ mod tests {
                     probe_volume: probe.volume,
                     center_distance_sq: (probe.center - object_center).length_squared(),
                     renderable_index: probe.renderable_index,
-                    skybox: probe.skybox,
                 },
             );
         }

--- a/crates/renderide/src/reflection_probes/specular/source.rs
+++ b/crates/renderide/src/reflection_probes/specular/source.rs
@@ -7,14 +7,15 @@ use crate::backend::frame_gpu::{
 };
 use crate::scene::{
     ReflectionProbeEntry, RenderSpaceId, SceneCoordinator, reflection_probe_skybox_only,
-    reflection_probe_use_box_projection,
+    reflection_probe_solid_color, reflection_probe_use_box_projection,
 };
-use crate::shared::{ReflectionProbeClear, ReflectionProbeState, ReflectionProbeType, RenderSH2};
+use crate::shared::{ReflectionProbeState, ReflectionProbeType, RenderSH2};
 use crate::skybox::specular::{
     CubemapIblSource, RuntimeCubemapIblSource, SkyboxIblSource, solid_color_ibl_source,
 };
 use crate::world_mesh::culling::world_aabb_from_local_bounds;
 
+use super::super::source_resolution::probe_clear_color;
 use super::captures::{RuntimeReflectionProbeCaptureKey, RuntimeReflectionProbeCaptureStore};
 use super::selection::{
     SpatialProbe, aabb_valid, aabb_volume, expanded_aabb, sanitized_blend_distance,
@@ -30,7 +31,7 @@ pub(super) fn resolve_probe_source(
     if state.intensity <= 0.0 {
         return None;
     }
-    if state.clear_flags == ReflectionProbeClear::Color {
+    if reflection_probe_solid_color(probe.state) {
         let color = state.background_color;
         return Some(solid_color_ibl_source(
             color_probe_identity(probe.renderable_index, color),
@@ -64,6 +65,7 @@ fn resolve_runtime_capture_source(
         face_size: capture.face_size,
         mip_levels: capture.mip_levels,
         storage_v_inverted: true,
+        clear_color: probe_clear_color(probe.state),
         texture: capture.texture.clone(),
         view: capture.view.clone(),
         array_view: capture.array_view.clone(),
@@ -91,6 +93,7 @@ pub(super) fn resolve_baked_probe_source(
         mip_levels_resident: cubemap.mip_levels_resident,
         content_generation: cubemap.content_generation,
         storage_v_inverted: cubemap.storage_v_inverted,
+        clear_color: probe_clear_color(state),
         view: cubemap.view.clone(),
         array_view: cubemap.array_view.clone(),
     }))
@@ -202,6 +205,7 @@ fn pack_render_sh2_raw(sh: &RenderSH2) -> [[f32; 4]; 9] {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::shared::ReflectionProbeClear;
 
     fn probe(index: i32, atlas: u16, importance: i32, min: Vec3, max: Vec3) -> SpatialProbe {
         let (influence_aabb_min, influence_aabb_max) = expanded_aabb(min, max, 0.0);

--- a/crates/renderide/src/reflection_probes/specular/system.rs
+++ b/crates/renderide/src/reflection_probes/specular/system.rs
@@ -7,8 +7,8 @@ use crate::backend::frame_gpu::{
     GpuReflectionProbeMetadata, REFLECTION_PROBE_ATLAS_FORMAT, ReflectionProbeSpecularResources,
 };
 use crate::gpu::GpuContext;
-use crate::scene::{RenderSpaceId, SceneCoordinator};
-use crate::shared::{ReflectionProbeClear, ReflectionProbeType, RenderSH2};
+use crate::scene::{RenderSpaceId, SceneCoordinator, reflection_probe_solid_color};
+use crate::shared::{ReflectionProbeType, RenderSH2};
 use crate::skybox::ibl_cache::{
     SkyboxIblCache, SkyboxIblKey, build_key, clamp_face_size, mip_extent, mip_levels_for_edge,
 };
@@ -151,7 +151,7 @@ impl ReflectionProbeSpecularSystem {
                 if matches!(
                     probe.state.r#type,
                     ReflectionProbeType::OnChanges | ReflectionProbeType::Realtime
-                ) && probe.state.clear_flags != ReflectionProbeClear::Color
+                ) && !reflection_probe_solid_color(probe.state)
                 {
                     collected
                         .active_capture_keys

--- a/crates/renderide/src/reflection_probes/specular/system.rs
+++ b/crates/renderide/src/reflection_probes/specular/system.rs
@@ -476,6 +476,7 @@ mod tests {
                 mip_levels: 1,
                 storage_v_inverted: true,
                 face_size: 128,
+                clear_color_key: None,
             },
             &spaces,
         ));
@@ -497,6 +498,7 @@ mod tests {
                 content_generation: 1,
                 storage_v_inverted: false,
                 face_size: 128,
+                clear_color_key: None,
             },
             &spaces,
         ));

--- a/crates/renderide/src/runtime/offscreen_tasks/reflection_probe/face.rs
+++ b/crates/renderide/src/runtime/offscreen_tasks/reflection_probe/face.rs
@@ -8,7 +8,7 @@ use glam::Vec3;
 use crate::camera::{CameraClipPlanes, HostCameraFrame};
 use crate::render_graph::FrameViewClear;
 use crate::scene::reflection_probe_skybox_only;
-use crate::shared::{CameraClearMode, ReflectionProbeClear, ReflectionProbeState};
+use crate::shared::{ReflectionProbeClear, ReflectionProbeState};
 use crate::world_mesh::CameraTransformDrawFilter;
 
 use super::super::cube_capture::host_camera_frame_for_cube_face;
@@ -47,10 +47,7 @@ pub(super) fn finite_positive_or(value: f32, fallback: f32) -> f32 {
 
 pub(super) fn clear_from_reflection_probe_state(state: ReflectionProbeState) -> FrameViewClear {
     if state.clear_flags == ReflectionProbeClear::Color {
-        FrameViewClear {
-            mode: CameraClearMode::Color,
-            color: state.background_color,
-        }
+        FrameViewClear::color(state.background_color)
     } else {
         FrameViewClear::skybox()
     }

--- a/crates/renderide/src/runtime/offscreen_tasks/reflection_probe/onchanges.rs
+++ b/crates/renderide/src/runtime/offscreen_tasks/reflection_probe/onchanges.rs
@@ -13,11 +13,10 @@ use crate::reflection_probes::specular::{
 use crate::render_graph::RenderPathProfile;
 use crate::scene::{
     ReflectionProbeOnChangesRenderRequest, RenderSpaceId, SceneCoordinator,
-    changed_probe_completion,
+    changed_probe_completion, reflection_probe_solid_color,
 };
 use crate::shared::{
-    ReflectionProbeClear, ReflectionProbeState, ReflectionProbeTimeSlicingMode,
-    ReflectionProbeType, RenderingContext,
+    ReflectionProbeState, ReflectionProbeTimeSlicingMode, ReflectionProbeType, RenderingContext,
 };
 
 use super::{
@@ -424,7 +423,7 @@ fn start_onchanges_reflection_probe_capture(
     let probe = space.reflection_probes().get(probe_index).ok_or(
         ReflectionProbeBakeError::MissingProbe(request.renderable_index),
     )?;
-    if probe.state.clear_flags == ReflectionProbeClear::Color {
+    if reflection_probe_solid_color(probe.state) {
         return Ok(OnChangesCaptureStart::ImmediateComplete);
     }
     if probe.state.r#type != ReflectionProbeType::OnChanges {
@@ -475,8 +474,7 @@ fn active_realtime_probe_keys(scene: &SceneCoordinator) -> Vec<RuntimeReflection
 
 /// Returns whether a probe state should have a realtime cubemap capture in flight.
 pub(in crate::runtime) fn realtime_probe_state_needs_capture(state: ReflectionProbeState) -> bool {
-    state.r#type == ReflectionProbeType::Realtime
-        && state.clear_flags != ReflectionProbeClear::Color
+    state.r#type == ReflectionProbeType::Realtime && !reflection_probe_solid_color(state)
 }
 
 /// Starts a realtime capture generation for one active probe.
@@ -487,9 +485,6 @@ fn start_realtime_reflection_probe_capture(
     generation: u64,
 ) -> Result<Box<ActiveRealtimeReflectionProbeCapture>, ReflectionProbeBakeError> {
     let state = realtime_capture_state(scene, key)?;
-    if state.clear_flags == ReflectionProbeClear::Color {
-        return Err(ReflectionProbeBakeError::MissingProbe(key.renderable_index));
-    }
     let extent = ProbeTaskExtent::from_size(state.resolution)?;
     let targets = create_probe_task_targets(gpu, extent)?;
     Ok(Box::new(ActiveRealtimeReflectionProbeCapture {
@@ -509,9 +504,6 @@ fn realtime_capture_is_still_valid(
     let Ok(state) = realtime_capture_state(scene, capture.key) else {
         return false;
     };
-    if state.clear_flags == ReflectionProbeClear::Color {
-        return false;
-    }
     match ProbeTaskExtent::from_size(state.resolution) {
         Ok(extent) => extent == capture.extent,
         Err(_error) => false,

--- a/crates/renderide/src/runtime/offscreen_tasks/reflection_probe/tests.rs
+++ b/crates/renderide/src/runtime/offscreen_tasks/reflection_probe/tests.rs
@@ -139,6 +139,15 @@ fn realtime_capture_scheduler_ignores_non_realtime_and_solid_color_states() {
         ReflectionProbeState {
             r#type: ReflectionProbeType::Realtime,
             clear_flags: ReflectionProbeClear::Color,
+            flags: 0x1,
+            ..Default::default()
+        }
+    ));
+    assert!(onchanges::realtime_probe_state_needs_capture(
+        ReflectionProbeState {
+            r#type: ReflectionProbeType::Realtime,
+            clear_flags: ReflectionProbeClear::Color,
+            flags: 0x0,
             ..Default::default()
         }
     ));

--- a/crates/renderide/src/scene.rs
+++ b/crates/renderide/src/scene.rs
@@ -85,6 +85,6 @@ pub(crate) use reflection_probe::changed_probe_completion;
 pub use reflection_probe::{
     DrainedReflectionProbeRenderChanges, ReflectionProbeEntry,
     ReflectionProbeOnChangesRenderRequest, reflection_probe_skybox_only,
-    reflection_probe_use_box_projection,
+    reflection_probe_solid_color, reflection_probe_use_box_projection,
 };
 pub use render_space::RenderSpaceView;

--- a/crates/renderide/src/scene/reflection_probe.rs
+++ b/crates/renderide/src/scene/reflection_probe.rs
@@ -4,7 +4,7 @@ use crate::color_space::srgb_vec4_rgb_to_linear;
 use crate::ipc::SharedMemoryAccessor;
 use crate::shared::{
     REFLECTION_PROBE_CHANGE_RENDER_TASK_HOST_ROW_BYTES, REFLECTION_PROBE_STATE_HOST_ROW_BYTES,
-    ReflectionProbeChangeRenderResult, ReflectionProbeChangeRenderTask,
+    ReflectionProbeChangeRenderResult, ReflectionProbeChangeRenderTask, ReflectionProbeClear,
     ReflectionProbeRenderablesUpdate, ReflectionProbeState, ReflectionProbeType,
 };
 
@@ -62,6 +62,14 @@ pub struct ReflectionProbeOnChangesRenderRequest {
 #[inline]
 pub fn reflection_probe_skybox_only(flags: u8) -> bool {
     flags & 0b001 != 0
+}
+
+/// Returns whether a probe state is a fixed solid color.
+#[inline]
+pub fn reflection_probe_solid_color(state: ReflectionProbeState) -> bool {
+    state.clear_flags == ReflectionProbeClear::Color
+        && reflection_probe_skybox_only(state.flags)
+        && state.r#type != ReflectionProbeType::Baked
 }
 
 /// Returns whether a probe state requests HDR rendering.
@@ -210,7 +218,7 @@ pub(crate) fn drain_reflection_probe_render_changes(
                 .push(changed_probe_completion(space.id.0, task.unique_id, true));
             continue;
         };
-        if entry.state.clear_flags == crate::shared::ReflectionProbeClear::Color {
+        if reflection_probe_solid_color(entry.state) {
             out.completed
                 .push(changed_probe_completion(space.id.0, task.unique_id, false));
         } else if entry.state.r#type == ReflectionProbeType::OnChanges {
@@ -368,8 +376,9 @@ mod tests {
             transform_id: 1,
             state: ReflectionProbeState {
                 renderable_index: 0,
-                clear_flags: crate::shared::ReflectionProbeClear::Color,
+                clear_flags: ReflectionProbeClear::Color,
                 r#type: ReflectionProbeType::OnChanges,
+                flags: 0x1,
                 ..ReflectionProbeState::default()
             },
         });

--- a/crates/renderide/src/skybox/ibl_cache/key.rs
+++ b/crates/renderide/src/skybox/ibl_cache/key.rs
@@ -40,6 +40,8 @@ pub(crate) enum SkyboxIblKey {
         storage_v_inverted: bool,
         /// Destination cube face edge.
         face_size: u32,
+        /// Clear color to use instead of the actual skybox, converted as bits for comparison
+        clear_color_key: Option<[u32; 4]>,
     },
     /// Constant-color reflection-probe identity.
     SolidColor {
@@ -64,6 +66,8 @@ pub(crate) enum SkyboxIblKey {
         storage_v_inverted: bool,
         /// Destination cube face edge.
         face_size: u32,
+        /// Clear color to use instead of the actual skybox, converted as bits for comparison
+        clear_color_key: Option<[u32; 4]>,
     },
 }
 
@@ -91,6 +95,7 @@ pub(crate) fn build_key(source: &SkyboxIblSource, face_size: u32) -> SkyboxIblKe
             content_generation: src.content_generation,
             storage_v_inverted: src.storage_v_inverted,
             face_size,
+            clear_color_key: src.clear_color.map(|c| c.to_array().map(|f| f.to_bits())),
         },
         SkyboxIblSource::SolidColor(src) => SkyboxIblKey::SolidColor {
             identity: src.identity,
@@ -104,6 +109,7 @@ pub(crate) fn build_key(source: &SkyboxIblSource, face_size: u32) -> SkyboxIblKe
             mip_levels: src.mip_levels,
             storage_v_inverted: src.storage_v_inverted,
             face_size,
+            clear_color_key: src.clear_color.map(|c| c.to_array().map(|f| f.to_bits())),
         },
     }
 }
@@ -239,6 +245,7 @@ mod tests {
             content_generation,
             storage_v_inverted: false,
             face_size,
+            clear_color_key: None,
         }
     }
 
@@ -250,6 +257,7 @@ mod tests {
             mip_levels: 1,
             storage_v_inverted,
             face_size: 128,
+            clear_color_key: None,
         }
     }
 }

--- a/crates/renderide/src/skybox/specular/solid_color.rs
+++ b/crates/renderide/src/skybox/specular/solid_color.rs
@@ -13,6 +13,7 @@ pub(crate) fn solid_color_ibl_source(identity: u64, color: [f32; 4]) -> SkyboxIb
 pub(crate) fn solid_color_params(color: [f32; 4]) -> SkyboxEvaluatorParams {
     let mut params = SkyboxEvaluatorParams::empty(SkyboxParamMode::Gradient);
     params.color0 = color;
+    params.sample_size = 1;
     params.gradient_count = 0;
     params
 }

--- a/crates/renderide/src/skybox/specular/source.rs
+++ b/crates/renderide/src/skybox/specular/source.rs
@@ -2,6 +2,8 @@
 
 use std::sync::Arc;
 
+use glam::Vec4;
+
 /// Reflection-probe source to be baked into a GGX-prefiltered cubemap.
 pub(crate) enum SkyboxIblSource {
     /// Resident host-uploaded cubemap read directly from a baked reflection probe.
@@ -32,6 +34,8 @@ pub(crate) struct CubemapIblSource {
     pub content_generation: u64,
     /// Whether sampling needs V-axis storage compensation.
     pub storage_v_inverted: bool,
+    /// Clear color to use instead of the actual skybox
+    pub clear_color: Option<Vec4>,
     /// Cube-dimension texture view used by cube-sampling systems such as SH projection.
     pub view: Arc<wgpu::TextureView>,
     /// 2D-array texture view used by manual seam-aware specular IBL filtering.
@@ -60,6 +64,8 @@ pub(crate) struct RuntimeCubemapIblSource {
     pub mip_levels: u32,
     /// Whether sampling needs V-axis storage compensation.
     pub storage_v_inverted: bool,
+    /// Clear color to use instead of the actual skybox
+    pub clear_color: Option<Vec4>,
     /// Captured texture retained with the source view.
     pub texture: Arc<wgpu::Texture>,
     /// Cube-dimension texture view used by cube-sampling systems such as SH projection.


### PR DESCRIPTION
Addresses #542 

- Allow rendering reflection probes with clear color if not skybox only. In this situation, the background color serves as the clear color for the draw render.
- Do not use consider background color at all for baked skyboxes