### PR TITLE
Add experimental setting to choose max number of local reflection probes

### DIFF
--- a/crates/renderide/shaders/modules/lighting/reflection_probes.wgsl
+++ b/crates/renderide/shaders/modules/lighting/reflection_probes.wgsl
@@ -146,7 +146,7 @@ fn add_importance_to_total(total: vec4<f32>, importance: ProbeBlendGroup) -> vec
     if (importance.weight_sum < MIN_PROBE_BLEND_WEIGHT || importance.coverage < MIN_PROBE_BLEND_WEIGHT) {
         return total;
     }
-    let remaining = min(importance.coverage, 1.0 - total.w);
+    let remaining = min(importance.weight_sum, 1.0 - total.w);
     let result = importance.weighted_result / importance.weight_sum;
     return total + vec4<f32>(result * remaining, remaining);
 }

--- a/crates/renderide/src/backend/facade.rs
+++ b/crates/renderide/src/backend/facade.rs
@@ -230,30 +230,19 @@ impl RenderBackend {
     }
 
     /// Snapshot of the live reflection-probe SH2 experimental toggle.
-    pub(crate) fn reflection_probe_sh2_enabled(&self) -> bool {
+    pub(crate) fn experimental_settings(&self) -> crate::config::ExperimentalSettings {
         self.renderer_settings
             .as_ref()
             .and_then(|h| h.read().ok())
-            .map(|s| s.experimental.reflection_probe_sh2_enabled)
-            .unwrap_or_else(|| {
-                crate::config::ExperimentalSettings::default().reflection_probe_sh2_enabled
-            })
-    }
-
-    /// Snapshot of the live development WGSL material hot-reload toggle.
-    pub(crate) fn material_shader_hot_reload_enabled(&self) -> bool {
-        self.renderer_settings
-            .as_ref()
-            .and_then(|h| h.read().ok())
-            .map(|s| s.experimental.material_shader_hot_reload_enabled)
-            .unwrap_or_else(|| {
-                crate::config::ExperimentalSettings::default().material_shader_hot_reload_enabled
-            })
+            .map(|s| s.experimental)
+            .unwrap_or_default()
     }
 
     /// Applies development WGSL hot-reload settings and polls for changed local material targets.
     pub(crate) fn sync_material_shader_hot_reload(&mut self) {
-        let enabled = self.material_shader_hot_reload_enabled();
+        let enabled = self
+            .experimental_settings()
+            .material_shader_hot_reload_enabled;
         self.materials.set_dev_shader_hot_reload_enabled(enabled);
         let report = self.materials.poll_dev_shader_hot_reload();
         if report.is_empty() {
@@ -368,13 +357,14 @@ impl RenderBackend {
         scene: &crate::scene::SceneCoordinator,
         render_context: crate::shared::RenderingContext,
     ) {
-        let reflection_probe_sh2_enabled = self.reflection_probe_sh2_enabled();
+        let experimental_settings = self.experimental_settings();
         let resources = self.reflection_probes.maintain_specular_jobs(
             gpu,
             scene,
             &self.asset_transfers,
             render_context,
-            reflection_probe_sh2_enabled,
+            experimental_settings.reflection_probe_sh2_enabled,
+            experimental_settings.max_local_reflection_probes,
         );
         let _ = self
             .frame_services

--- a/crates/renderide/src/backend/facade/reflection_services.rs
+++ b/crates/renderide/src/backend/facade/reflection_services.rs
@@ -68,6 +68,7 @@ impl ReflectionProbeServices {
         asset_transfers: &AssetTransferQueue,
         render_context: RenderingContext,
         reflection_probe_sh2_enabled: bool,
+        max_local_reflection_probes: usize,
     ) -> Option<ReflectionProbeSpecularResources> {
         self.specular
             .maintain(ReflectionProbeSpecularMaintainParams {
@@ -77,6 +78,7 @@ impl ReflectionProbeServices {
                 render_context,
                 sh2_system: &mut self.sh2,
                 reflection_probe_sh2_enabled,
+                max_local_reflection_probes,
             });
         self.specular.resources()
     }

--- a/crates/renderide/src/config/types/experimental.rs
+++ b/crates/renderide/src/config/types/experimental.rs
@@ -3,11 +3,23 @@
 use serde::{Deserialize, Serialize};
 
 /// Feature flags for renderer behavior that is still experimental.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct ExperimentalSettings {
+    /// Maximum number of local reflection probes that can contribute to reflections on a single mesh.
+    pub max_local_reflection_probes: usize,
     /// Whether reflection probes may contribute SH2 indirect diffuse lighting.
     pub reflection_probe_sh2_enabled: bool,
     /// Whether local `shaders/target/*.wgsl` edits invalidate and reload material pipelines in development builds.
     pub material_shader_hot_reload_enabled: bool,
+}
+
+impl Default for ExperimentalSettings {
+    fn default() -> Self {
+        Self {
+            max_local_reflection_probes: 2,
+            reflection_probe_sh2_enabled: false,
+            material_shader_hot_reload_enabled: false,
+        }
+    }
 }

--- a/crates/renderide/src/diagnostics/hud/windows/renderer_config/experimental.rs
+++ b/crates/renderide/src/diagnostics/hud/windows/renderer_config/experimental.rs
@@ -2,10 +2,22 @@
 
 use crate::config::RendererSettings;
 
+use crate::reflection_probes::specular::MAX_LOCAL_PROBES;
+
 /// Experimental feature flags.
 pub(super) fn experimental_section(ui: &imgui::Ui, g: &mut RendererSettings, dirty: &mut bool) {
     ui.text("Experimental");
     ui.indent();
+    let mut mrp = g.experimental.max_local_reflection_probes;
+    if ui.slider(
+        "Maximum number of local reflection probes per mesh",
+        0,
+        MAX_LOCAL_PROBES,
+        &mut mrp,
+    ) {
+        g.experimental.max_local_reflection_probes = mrp.clamp(0, MAX_LOCAL_PROBES);
+        *dirty = true;
+    }
     if ui.checkbox(
         "Use reflection probe SH2",
         &mut g.experimental.reflection_probe_sh2_enabled,

--- a/crates/renderide/src/reflection_probes/specular.rs
+++ b/crates/renderide/src/reflection_probes/specular.rs
@@ -10,6 +10,7 @@ pub(crate) use captures::{
     RuntimeReflectionProbeCapture, RuntimeReflectionProbeCaptureKey,
     RuntimeReflectionProbeCaptureStore,
 };
+pub(crate) use selection::MAX_LOCAL_PROBES;
 pub use selection::{ReflectionProbeDrawSelection, ReflectionProbeFrameSelection};
 pub(crate) use system::ReflectionProbeSpecularMaintainParams;
 pub use system::ReflectionProbeSpecularSystem;

--- a/crates/renderide/src/reflection_probes/specular/selection.rs
+++ b/crates/renderide/src/reflection_probes/specular/selection.rs
@@ -159,7 +159,6 @@ impl ReflectionProbeSpatialIndex {
                         probe_volume: probe.volume,
                         center_distance_sq: (probe.center - object_center).length_squared(),
                         renderable_index: probe.renderable_index,
-                        skybox: probe.skybox,
                     };
                     if probe.skybox {
                         if aabb_contains(probe.aabb_min, probe.aabb_max, object_min, object_max) {
@@ -275,7 +274,6 @@ struct ProbeScore {
     probe_volume: f32,
     center_distance_sq: f32,
     renderable_index: i32,
-    skybox: bool,
 }
 
 /// Order of preference:
@@ -289,7 +287,6 @@ fn score_better(a: ProbeScore, b: ProbeScore) -> bool {
     a.importance
         .cmp(&b.importance)
         .reverse()
-        .then_with(|| a.skybox.cmp(&b.skybox))
         .then_with(|| {
             a.influence_intersection
                 .total_cmp(&b.influence_intersection)
@@ -738,7 +735,6 @@ mod tests {
                     probe_volume: probe.volume,
                     center_distance_sq: (probe.center - object_center).length_squared(),
                     renderable_index: probe.renderable_index,
-                    skybox: probe.skybox,
                 },
             );
         }

--- a/crates/renderide/src/reflection_probes/specular/selection.rs
+++ b/crates/renderide/src/reflection_probes/specular/selection.rs
@@ -175,7 +175,7 @@ impl ReflectionProbeSpatialIndex {
                 stack.push(node.right);
             }
         }
-        self.selection_from_scores(top, fallback)
+        selection_from_scores(top, fallback)
     }
 
     fn build_node(&mut self, order: &mut [usize], start: usize, end: usize) -> usize {
@@ -226,34 +226,6 @@ impl ReflectionProbeSpatialIndex {
             top.push(score);
         }
     }
-
-    fn selection_from_scores(
-        &self,
-        top: Vec<ProbeScore>,
-        fallback: Option<ProbeScore>,
-    ) -> ReflectionProbeDrawSelection {
-        let mut atlas_indices = [0u16; MAX_LOCAL_PROBES + 1];
-        let mut importance_mask = 0u8;
-        let mut previous_importance = None;
-        if let Some(probe) = fallback {
-            atlas_indices[0] = probe.atlas_index;
-        }
-        for (i, probe) in top
-            .iter()
-            .take(self.max_local_reflection_probes)
-            .enumerate()
-        {
-            atlas_indices[i + 1] = probe.atlas_index;
-            if previous_importance.is_some_and(|importance| probe.importance < importance) {
-                importance_mask |= 1 << i;
-            }
-            previous_importance = Some(probe.importance);
-        }
-        ReflectionProbeDrawSelection {
-            atlas_indices,
-            importance_mask,
-        }
-    }
 }
 
 #[derive(Clone, Copy)]
@@ -277,25 +249,43 @@ struct ProbeScore {
 }
 
 /// Order of preference:
-/// 1. Largest importance set by creator
-/// 2. Non-skybox preferred over skybox
-/// 3. Largest influence intersection
-/// 4. Smallest probe volume
-/// 5. Closest to the center
-/// 6. Lowest renderable index
+/// 1. Largest influence intersection
+/// 2. Smallest probe volume
+/// 3. Closest to the center
+/// 4. Lowest renderable index
 fn score_better(a: ProbeScore, b: ProbeScore) -> bool {
-    a.importance
-        .cmp(&b.importance)
+    a.influence_intersection
+        .total_cmp(&b.influence_intersection)
         .reverse()
-        .then_with(|| {
-            a.influence_intersection
-                .total_cmp(&b.influence_intersection)
-                .reverse()
-        })
         .then_with(|| a.probe_volume.total_cmp(&b.probe_volume))
         .then_with(|| a.center_distance_sq.total_cmp(&b.center_distance_sq))
         .then_with(|| a.renderable_index.cmp(&b.renderable_index))
         .is_lt()
+}
+
+fn selection_from_scores(
+    mut top: Vec<ProbeScore>,
+    fallback: Option<ProbeScore>,
+) -> ReflectionProbeDrawSelection {
+    let mut atlas_indices = [0u16; MAX_LOCAL_PROBES + 1];
+    let mut importance_mask = 0u8;
+    let mut previous_importance = None;
+    if let Some(probe) = fallback {
+        atlas_indices[0] = probe.atlas_index;
+    }
+    // Stable reorder by descending importance to keep the scoring order
+    top.sort_by_key(|probe| -probe.importance);
+    for (i, probe) in top.iter().enumerate() {
+        atlas_indices[i + 1] = probe.atlas_index;
+        if previous_importance.is_some_and(|importance| probe.importance < importance) {
+            importance_mask |= 1 << i;
+        }
+        previous_importance = Some(probe.importance);
+    }
+    ReflectionProbeDrawSelection {
+        atlas_indices,
+        importance_mask,
+    }
 }
 
 fn bounds_for_order(probes: &[SpatialProbe], order: &[usize]) -> (Vec3A, Vec3A) {
@@ -691,7 +681,7 @@ mod tests {
 
         let selection = index.select((Vec3::splat(-5.0), Vec3::splat(5.0)));
 
-        assert_eq!(selection, expected_selection(3, [1, 0, 0, 0], 0b0000));
+        assert_eq!(selection, expected_selection(3, [2, 0, 0, 0], 0b0000));
     }
 
     #[test]

--- a/crates/renderide/src/reflection_probes/specular/selection.rs
+++ b/crates/renderide/src/reflection_probes/specular/selection.rs
@@ -6,14 +6,14 @@ use crate::scene::RenderSpaceId;
 /// Maximum number of probes in one BVH leaf.
 const BVH_LEAF_SIZE: usize = 8;
 const MIN_BLEND_DISTANCE: f32 = 1e-6;
-const MAX_LOCAL_PROBES: usize = 4;
+pub const MAX_LOCAL_PROBES: usize = 4;
 const CONTAINMENT_EPSILON: f32 = 1e-5;
 
 /// Per-draw reflection-probe selection stored in the per-draw slab.
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct ReflectionProbeDrawSelection {
     /// Atlas indices ordered as `[global_fallback, local0, local1, local2, local3]`.
-    pub atlas_indices: [u16; 5],
+    pub atlas_indices: [u16; MAX_LOCAL_PROBES + 1],
     /// Bit mask marking local probes that start a lower-importance group than their predecessor.
     pub importance_mask: u8,
 }
@@ -29,9 +29,18 @@ impl ReflectionProbeDrawSelection {
 }
 
 /// CPU-side selector snapshot used during world-mesh draw collection.
-#[derive(Default)]
 pub struct ReflectionProbeFrameSelection {
     spaces: HashMap<RenderSpaceId, ReflectionProbeSpatialIndex>,
+    pub(super) max_local_reflection_probes: usize,
+}
+
+impl Default for ReflectionProbeFrameSelection {
+    fn default() -> Self {
+        Self {
+            spaces: Default::default(),
+            max_local_reflection_probes: 2,
+        }
+    }
 }
 
 impl ReflectionProbeFrameSelection {
@@ -63,8 +72,10 @@ impl ReflectionProbeFrameSelection {
             by_space.entry(space_id).or_default().push(probe);
         }
         for (space_id, probes) in by_space {
-            self.spaces
-                .insert(space_id, ReflectionProbeSpatialIndex::build(probes));
+            self.spaces.insert(
+                space_id,
+                ReflectionProbeSpatialIndex::build(probes, self.max_local_reflection_probes),
+            );
         }
     }
 }
@@ -87,15 +98,17 @@ pub(super) struct SpatialProbe {
 #[derive(Default)]
 pub struct ReflectionProbeSpatialIndex {
     probes: Vec<SpatialProbe>,
+    max_local_reflection_probes: usize,
     order: Vec<usize>,
     nodes: Vec<BvhNode>,
     root: Option<usize>,
 }
 
 impl ReflectionProbeSpatialIndex {
-    pub(super) fn build(probes: Vec<SpatialProbe>) -> Self {
+    pub(super) fn build(probes: Vec<SpatialProbe>, max_local_reflection_probes: usize) -> Self {
         let mut out = Self {
             order: (0..probes.len()).collect(),
+            max_local_reflection_probes,
             probes,
             nodes: Vec::new(),
             root: None,
@@ -156,14 +169,14 @@ impl ReflectionProbeSpatialIndex {
                         }
                         continue;
                     }
-                    insert_probe_score(&mut top, score);
+                    self.insert_probe_score(&mut top, score);
                 }
             } else {
                 stack.push(node.left);
                 stack.push(node.right);
             }
         }
-        selection_from_scores(top, fallback)
+        self.selection_from_scores(top, fallback)
     }
 
     fn build_node(&mut self, order: &mut [usize], start: usize, end: usize) -> usize {
@@ -199,6 +212,49 @@ impl ReflectionProbeSpatialIndex {
         self.nodes[index].right = right;
         index
     }
+
+    fn insert_probe_score(&self, top: &mut Vec<ProbeScore>, score: ProbeScore) {
+        for i in 0..top.len() {
+            if score_better(score, top[i]) {
+                top.insert(i, score);
+                if top.len() > self.max_local_reflection_probes {
+                    top.pop();
+                }
+                return;
+            }
+        }
+        if top.len() < self.max_local_reflection_probes {
+            top.push(score);
+        }
+    }
+
+    fn selection_from_scores(
+        &self,
+        top: Vec<ProbeScore>,
+        fallback: Option<ProbeScore>,
+    ) -> ReflectionProbeDrawSelection {
+        let mut atlas_indices = [0u16; MAX_LOCAL_PROBES + 1];
+        let mut importance_mask = 0u8;
+        let mut previous_importance = None;
+        if let Some(probe) = fallback {
+            atlas_indices[0] = probe.atlas_index;
+        }
+        for (i, probe) in top
+            .iter()
+            .take(self.max_local_reflection_probes)
+            .enumerate()
+        {
+            atlas_indices[i + 1] = probe.atlas_index;
+            if previous_importance.is_some_and(|importance| probe.importance < importance) {
+                importance_mask |= 1 << i;
+            }
+            previous_importance = Some(probe.importance);
+        }
+        ReflectionProbeDrawSelection {
+            atlas_indices,
+            importance_mask,
+        }
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -222,21 +278,6 @@ struct ProbeScore {
     skybox: bool,
 }
 
-fn insert_probe_score(top: &mut Vec<ProbeScore>, score: ProbeScore) {
-    for i in 0..top.len() {
-        if score_better(score, top[i]) {
-            top.insert(i, score);
-            if top.len() > MAX_LOCAL_PROBES {
-                top.pop();
-            }
-            return;
-        }
-    }
-    if top.len() < MAX_LOCAL_PROBES {
-        top.push(score);
-    }
-}
-
 /// Order of preference:
 /// 1. Largest importance set by creator
 /// 2. Non-skybox preferred over skybox
@@ -258,29 +299,6 @@ fn score_better(a: ProbeScore, b: ProbeScore) -> bool {
         .then_with(|| a.center_distance_sq.total_cmp(&b.center_distance_sq))
         .then_with(|| a.renderable_index.cmp(&b.renderable_index))
         .is_lt()
-}
-
-fn selection_from_scores(
-    top: Vec<ProbeScore>,
-    fallback: Option<ProbeScore>,
-) -> ReflectionProbeDrawSelection {
-    let mut atlas_indices = [0u16; 5];
-    let mut importance_mask = 0u8;
-    let mut previous_importance = None;
-    if let Some(probe) = fallback {
-        atlas_indices[0] = probe.atlas_index;
-    }
-    for (i, probe) in top.iter().take(MAX_LOCAL_PROBES).enumerate() {
-        atlas_indices[i + 1] = probe.atlas_index;
-        if previous_importance.is_some_and(|importance| probe.importance < importance) {
-            importance_mask |= 1 << i;
-        }
-        previous_importance = Some(probe.importance);
-    }
-    ReflectionProbeDrawSelection {
-        atlas_indices,
-        importance_mask,
-    }
 }
 
 fn bounds_for_order(probes: &[SpatialProbe], order: &[usize]) -> (Vec3A, Vec3A) {
@@ -369,7 +387,7 @@ mod tests {
         local_atlas_indices: [u16; MAX_LOCAL_PROBES],
         importance_mask: u8,
     ) -> ReflectionProbeDrawSelection {
-        let mut atlas_indices = [0; 5];
+        let mut atlas_indices = [0; MAX_LOCAL_PROBES + 1];
         atlas_indices[0] = fallback_atlas_index;
         atlas_indices[1..].copy_from_slice(&local_atlas_indices);
         ReflectionProbeDrawSelection {
@@ -424,10 +442,13 @@ mod tests {
 
     #[test]
     fn higher_priority_overrides_lower_priority() {
-        let index = ReflectionProbeSpatialIndex::build(vec![
-            probe(0, 1, 0, Vec3::splat(-100.0), Vec3::splat(100.0)),
-            probe(1, 2, 1, Vec3::splat(-1.0), Vec3::splat(1.0)),
-        ]);
+        let index = ReflectionProbeSpatialIndex::build(
+            vec![
+                probe(0, 1, 0, Vec3::splat(-100.0), Vec3::splat(100.0)),
+                probe(1, 2, 1, Vec3::splat(-1.0), Vec3::splat(1.0)),
+            ],
+            MAX_LOCAL_PROBES,
+        );
 
         let selection = index.select((Vec3::splat(-0.25), Vec3::splat(0.25)));
 
@@ -477,14 +498,17 @@ mod tests {
 
     #[test]
     fn blend_distance_selects_probe_outside_original_bounds() {
-        let index = ReflectionProbeSpatialIndex::build(vec![probe_with_blend(
-            0,
-            1,
-            1,
-            Vec3::splat(-1.0),
-            Vec3::splat(1.0),
-            0.75,
-        )]);
+        let index = ReflectionProbeSpatialIndex::build(
+            vec![probe_with_blend(
+                0,
+                1,
+                1,
+                Vec3::splat(-1.0),
+                Vec3::splat(1.0),
+                0.75,
+            )],
+            MAX_LOCAL_PROBES,
+        );
 
         let selection = index.select((Vec3::new(1.25, -0.25, -0.25), Vec3::new(1.5, 0.25, 0.25)));
 
@@ -510,10 +534,13 @@ mod tests {
 
     #[test]
     fn higher_priority_overrides_lower_priority_in_blend_fringe() {
-        let index = ReflectionProbeSpatialIndex::build(vec![
-            probe_with_blend(0, 1, 0, Vec3::splat(-5.0), Vec3::splat(5.0), 0.0),
-            probe_with_blend(1, 2, 1, Vec3::splat(-1.0), Vec3::splat(1.0), 1.0),
-        ]);
+        let index = ReflectionProbeSpatialIndex::build(
+            vec![
+                probe_with_blend(0, 1, 0, Vec3::splat(-5.0), Vec3::splat(5.0), 0.0),
+                probe_with_blend(1, 2, 1, Vec3::splat(-1.0), Vec3::splat(1.0), 1.0),
+            ],
+            MAX_LOCAL_PROBES,
+        );
 
         let selection = index.select((Vec3::new(1.2, -0.1, -0.1), Vec3::new(1.4, 0.1, 0.1)));
 
@@ -522,29 +549,32 @@ mod tests {
 
     #[test]
     fn same_importance_selects_two_by_intersection_volume() {
-        let index = ReflectionProbeSpatialIndex::build(vec![
-            probe(
-                0,
-                1,
-                1,
-                Vec3::new(-1.0, -1.0, -1.0),
-                Vec3::new(1.0, 1.0, 1.0),
-            ),
-            probe(
-                1,
-                2,
-                1,
-                Vec3::new(0.0, -1.0, -1.0),
-                Vec3::new(2.0, 1.0, 1.0),
-            ),
-            probe(
-                2,
-                3,
-                1,
-                Vec3::new(0.75, -1.0, -1.0),
-                Vec3::new(2.0, 1.0, 1.0),
-            ),
-        ]);
+        let index = ReflectionProbeSpatialIndex::build(
+            vec![
+                probe(
+                    0,
+                    1,
+                    1,
+                    Vec3::new(-1.0, -1.0, -1.0),
+                    Vec3::new(1.0, 1.0, 1.0),
+                ),
+                probe(
+                    1,
+                    2,
+                    1,
+                    Vec3::new(0.0, -1.0, -1.0),
+                    Vec3::new(2.0, 1.0, 1.0),
+                ),
+                probe(
+                    2,
+                    3,
+                    1,
+                    Vec3::new(0.75, -1.0, -1.0),
+                    Vec3::new(2.0, 1.0, 1.0),
+                ),
+            ],
+            MAX_LOCAL_PROBES,
+        );
 
         let selection = index.select((Vec3::new(-0.5, -0.5, -0.5), Vec3::new(1.5, 0.5, 0.5)));
 
@@ -553,10 +583,13 @@ mod tests {
 
     #[test]
     fn contained_same_importance_probe_selects_inner_in_higher_priority_when_object_fully_inside() {
-        let index = ReflectionProbeSpatialIndex::build(vec![
-            probe(0, 1, 1, Vec3::splat(-10.0), Vec3::splat(10.0)),
-            probe(1, 2, 1, Vec3::splat(-1.0), Vec3::splat(1.0)),
-        ]);
+        let index = ReflectionProbeSpatialIndex::build(
+            vec![
+                probe(0, 1, 1, Vec3::splat(-10.0), Vec3::splat(10.0)),
+                probe(1, 2, 1, Vec3::splat(-1.0), Vec3::splat(1.0)),
+            ],
+            MAX_LOCAL_PROBES,
+        );
 
         let selection = index.select((Vec3::splat(-0.5), Vec3::splat(0.5)));
 
@@ -565,10 +598,13 @@ mod tests {
 
     #[test]
     fn contained_same_importance_probe_blends_when_object_partially_leaves_inner() {
-        let index = ReflectionProbeSpatialIndex::build(vec![
-            probe(0, 1, 1, Vec3::splat(-10.0), Vec3::splat(10.0)),
-            probe(1, 2, 1, Vec3::splat(-1.0), Vec3::splat(1.0)),
-        ]);
+        let index = ReflectionProbeSpatialIndex::build(
+            vec![
+                probe(0, 1, 1, Vec3::splat(-10.0), Vec3::splat(10.0)),
+                probe(1, 2, 1, Vec3::splat(-1.0), Vec3::splat(1.0)),
+            ],
+            MAX_LOCAL_PROBES,
+        );
 
         let selection = index.select((Vec3::new(-0.5, -0.5, -0.5), Vec3::new(1.5, 0.5, 0.5)));
 
@@ -577,10 +613,13 @@ mod tests {
 
     #[test]
     fn identical_same_importance_probe_boxes_use_intersection_blend() {
-        let index = ReflectionProbeSpatialIndex::build(vec![
-            probe(0, 1, 1, Vec3::splat(-1.0), Vec3::splat(1.0)),
-            probe(1, 2, 1, Vec3::splat(-1.0), Vec3::splat(1.0)),
-        ]);
+        let index = ReflectionProbeSpatialIndex::build(
+            vec![
+                probe(0, 1, 1, Vec3::splat(-1.0), Vec3::splat(1.0)),
+                probe(1, 2, 1, Vec3::splat(-1.0), Vec3::splat(1.0)),
+            ],
+            MAX_LOCAL_PROBES,
+        );
 
         let selection = index.select((Vec3::splat(-0.5), Vec3::splat(0.5)));
 
@@ -589,12 +628,15 @@ mod tests {
 
     #[test]
     fn skybox_probe_terrible_candidate_but_used_as_fallback() {
-        let index = ReflectionProbeSpatialIndex::build(vec![
-            probe(0, 1, 0, Vec3::splat(-1.0), Vec3::splat(1.0)),
-            probe(1, 2, 0, Vec3::splat(-1.0), Vec3::splat(1.0)),
-            skybox_probe(2, 3, 0, Vec3::splat(-1000.0), Vec3::splat(1000.0)),
-            skybox_probe(3, 4, 0, Vec3::splat(-10_000.0), Vec3::splat(10_000.0)),
-        ]);
+        let index = ReflectionProbeSpatialIndex::build(
+            vec![
+                probe(0, 1, 0, Vec3::splat(-1.0), Vec3::splat(1.0)),
+                probe(1, 2, 0, Vec3::splat(-1.0), Vec3::splat(1.0)),
+                skybox_probe(2, 3, 0, Vec3::splat(-1000.0), Vec3::splat(1000.0)),
+                skybox_probe(3, 4, 0, Vec3::splat(-10_000.0), Vec3::splat(10_000.0)),
+            ],
+            MAX_LOCAL_PROBES,
+        );
 
         let selection = index.select((Vec3::splat(-0.5), Vec3::splat(0.5)));
 
@@ -603,15 +645,18 @@ mod tests {
 
     #[test]
     fn skybox_fallback_requires_original_bounds_containment() {
-        let index = ReflectionProbeSpatialIndex::build(vec![full_probe(
-            0,
-            3,
-            0,
-            Vec3::splat(-1.0),
-            Vec3::splat(1.0),
-            1.0,
-            true,
-        )]);
+        let index = ReflectionProbeSpatialIndex::build(
+            vec![full_probe(
+                0,
+                3,
+                0,
+                Vec3::splat(-1.0),
+                Vec3::splat(1.0),
+                1.0,
+                true,
+            )],
+            MAX_LOCAL_PROBES,
+        );
 
         let selection = index.select((Vec3::new(1.25, -0.25, -0.25), Vec3::new(1.5, 0.25, 0.25)));
 
@@ -620,16 +665,36 @@ mod tests {
 
     #[test]
     fn probes_of_different_importance_respect_hierarchy_and_have_fallback() {
-        let index = ReflectionProbeSpatialIndex::build(vec![
-            probe(0, 1, 2, Vec3::splat(-1.0), Vec3::splat(1.0)),
-            probe(1, 2, 1, Vec3::splat(-3.0), Vec3::splat(3.0)),
-            skybox_probe(2, 3, 0, Vec3::splat(-1000.0), Vec3::splat(1000.0)),
-            skybox_probe(3, 4, 0, Vec3::splat(-10_000.0), Vec3::splat(10_000.0)),
-        ]);
+        let index = ReflectionProbeSpatialIndex::build(
+            vec![
+                probe(0, 1, 2, Vec3::splat(-1.0), Vec3::splat(1.0)),
+                probe(1, 2, 1, Vec3::splat(-3.0), Vec3::splat(3.0)),
+                skybox_probe(2, 3, 0, Vec3::splat(-1000.0), Vec3::splat(1000.0)),
+                skybox_probe(3, 4, 0, Vec3::splat(-10_000.0), Vec3::splat(10_000.0)),
+            ],
+            MAX_LOCAL_PROBES,
+        );
 
         let selection = index.select((Vec3::splat(-5.0), Vec3::splat(5.0)));
 
         assert_eq!(selection, expected_selection(3, [1, 2, 0, 0], 0b0010));
+    }
+
+    #[test]
+    fn limits_number_of_selected_probes_depending_on_settings() {
+        let index = ReflectionProbeSpatialIndex::build(
+            vec![
+                probe(0, 1, 2, Vec3::splat(-1.0), Vec3::splat(1.0)),
+                probe(1, 2, 1, Vec3::splat(-3.0), Vec3::splat(3.0)),
+                skybox_probe(2, 3, 0, Vec3::splat(-1000.0), Vec3::splat(1000.0)),
+                skybox_probe(3, 4, 0, Vec3::splat(-10_000.0), Vec3::splat(10_000.0)),
+            ],
+            1,
+        );
+
+        let selection = index.select((Vec3::splat(-5.0), Vec3::splat(5.0)));
+
+        assert_eq!(selection, expected_selection(3, [1, 0, 0, 0], 0b0000));
     }
 
     #[test]
@@ -646,7 +711,7 @@ mod tests {
                 )
             })
             .collect();
-        let index = ReflectionProbeSpatialIndex::build(probes.clone());
+        let index = ReflectionProbeSpatialIndex::build(probes.clone(), MAX_LOCAL_PROBES);
         let object = (Vec3::new(4.2, -0.25, -0.25), Vec3::new(6.1, 0.25, 0.25));
         let selection = index.select(object);
 
@@ -664,7 +729,7 @@ mod tests {
             if influence_intersection < MIN_BLEND_DISTANCE {
                 continue;
             }
-            insert_probe_score(
+            index.insert_probe_score(
                 &mut brute,
                 ProbeScore {
                     atlas_index: probe.atlas_index,

--- a/crates/renderide/src/reflection_probes/specular/system.rs
+++ b/crates/renderide/src/reflection_probes/specular/system.rs
@@ -41,6 +41,8 @@ pub(crate) struct ReflectionProbeSpecularMaintainParams<'a> {
     pub(crate) sh2_system: &'a mut ReflectionProbeSh2System,
     /// Whether reflection probes should contribute SH2 indirect diffuse lighting.
     pub(crate) reflection_probe_sh2_enabled: bool,
+    /// Maximum number of local reflection probes that can contribute to reflections on a single mesh.
+    pub(crate) max_local_reflection_probes: usize,
 }
 
 /// Specular reflection-probe bake/cache/selection system.
@@ -118,6 +120,7 @@ impl ReflectionProbeSpecularSystem {
         let face_size = clamp_face_size(DEFAULT_REFLECTION_PROBE_FACE_SIZE, params.gpu.limits());
         let mut collected = CollectedProbeResources::default();
 
+        self.selection.max_local_reflection_probes = params.max_local_reflection_probes;
         self.collect_probe_resources(&mut params, face_size, &mut collected);
         self.captures.retain_active(&collected.active_capture_keys);
         self.last_ready

--- a/crates/renderide/src/world_mesh/culling/frustum.rs
+++ b/crates/renderide/src/world_mesh/culling/frustum.rs
@@ -123,15 +123,18 @@ impl Frustum {
     }
 }
 
-fn model_matrix_is_affine_bottom_row(m: Mat4) -> bool {
-    let r = m.row(3);
-    r.x.abs() <= MODEL_MATRIX_AFFINE_BOTTOM_EPS
-        && r.y.abs() <= MODEL_MATRIX_AFFINE_BOTTOM_EPS
-        && r.z.abs() <= MODEL_MATRIX_AFFINE_BOTTOM_EPS
-        && (r.w - 1.0).abs() <= MODEL_MATRIX_AFFINE_BOTTOM_EPS
+fn row_is_world_aligned(v: Vec3) -> bool {
+    let l = v.length();
+    l - v.abs().max_element() <= MODEL_MATRIX_AFFINE_BOTTOM_EPS * l
 }
 
-fn world_aabb_from_local_bounds_affine(
+fn model_matrix_is_world_aligned(m: Mat4) -> bool {
+    row_is_world_aligned(m.row(0).xyz())
+        && row_is_world_aligned(m.row(1).xyz())
+        && row_is_world_aligned(m.row(2).xyz())
+}
+
+fn world_aabb_from_local_bounds_world_aligned(
     bounds: &RenderBoundingBox,
     m: Mat4,
 ) -> Option<(Vec3, Vec3)> {
@@ -231,8 +234,8 @@ pub fn world_aabb_from_local_bounds(
     bounds: &RenderBoundingBox,
     model_matrix: Mat4,
 ) -> Option<(Vec3, Vec3)> {
-    if model_matrix_is_affine_bottom_row(model_matrix) {
-        world_aabb_from_local_bounds_affine(bounds, model_matrix)
+    if model_matrix_is_world_aligned(model_matrix) {
+        world_aabb_from_local_bounds_world_aligned(bounds, model_matrix)
     } else {
         world_aabb_from_local_bounds_bruteforce(bounds, model_matrix)
     }


### PR DESCRIPTION
Also took the opportunity to set the default to 2 instead of 4, as it might help a bit with performance for a minimal visual impact.