### PR TITLE
remove unnecessary sync on the audio sink

### DIFF
--- a/crates/renderide/src/assets/video/audio_sink.rs
+++ b/crates/renderide/src/assets/video/audio_sink.rs
@@ -28,7 +28,6 @@ impl ResoniteAudioSink {
             )
             .max_buffers(1)
             .drop(true)
-            .sync(true)
             .build();
 
         Self { sink }


### PR DESCRIPTION
Fixes audio-only files (such as mp3) not playing.

As far as I can tell removing this doesn't cause any other problems, it was likely added during early testing and never removed.