### PR TITLE
Add grace margin to intersect shader

### DIFF
--- a/crates/renderide/shaders/modules/core/math.wgsl
+++ b/crates/renderide/shaders/modules/core/math.wgsl
@@ -2,7 +2,8 @@
 
 #define_import_path renderide::core::math
 
-const EPSILON: f32 = 1e-6;
+const EPSILON: f32 = 1e-4;
+const EPSILON_AREA: f32 = 1e-6;
 
 fn saturate(v: f32) -> f32 {
     return clamp(v, 0.0, 1.0);
@@ -21,19 +22,21 @@ fn safe_normalize(v: vec3<f32>, fallback: vec3<f32>) -> vec3<f32> {
 }
 
 fn safe_lerp_factor(start_value: f32, end_value: f32, value: f32) -> f32 {
+    let num = value - start_value;
     let denom = end_value - start_value;
     if (abs(denom) < EPSILON) {
-        return select(0.0, 1.0, value <= start_value);
+        return select(0.0, 1.0, num < EPSILON);
     }
-    return saturate((value - start_value) / denom);
+    return saturate(num / denom);
 }
 
 fn safe_linear_factor(start_value: f32, end_value: f32, value: f32) -> f32 {
+    let num = value - start_value;
     let denom = end_value - start_value;
     if (abs(denom) < EPSILON) {
-        return select(0.0, 1.0, value >= end_value);
+        return select(0.0, 1.0, num >= EPSILON);
     }
-    return saturate((value - start_value) / denom);
+    return saturate(num / denom);
 }
 
 fn rotate2(v: vec2<f32>, angle: f32) -> vec2<f32> {
@@ -44,7 +47,7 @@ fn rotate2(v: vec2<f32>, angle: f32) -> vec2<f32> {
 
 fn rect_has_area(rect: vec4<f32>) -> bool {
     let size = rect.zw - rect.xy;
-    return abs(size.x * size.y) > EPSILON;
+    return abs(size.x * size.y) > EPSILON_AREA;
 }
 
 fn outside_rect(p: vec2<f32>, rect: vec4<f32>) -> bool {

--- a/crates/renderide/shaders/modules/pbs/families/intersect.wgsl
+++ b/crates/renderide/shaders/modules/pbs/families/intersect.wgsl
@@ -5,6 +5,8 @@
 #import renderide::core::math as rmath
 #import renderide::frame::scene_depth_sample as sds
 
+const EPSILON: f32 = 1e-4;
+
 fn intersection_lerp(
     frag_pos: vec4<f32>,
     world_pos: vec3<f32>,
@@ -15,7 +17,7 @@ fn intersection_lerp(
     end_end: f32,
 ) -> f32 {
     let diff = sds::scene_linear_depth(frag_pos, view_layer) - sds::fragment_linear_depth(world_pos, view_layer);
-    if (diff < end_start) {
+    if (diff < min(begin_end, end_start) + EPSILON) {
         return rmath::safe_linear_factor(begin_start, begin_end, diff);
     }
     return 1.0 - rmath::safe_linear_factor(end_start, end_end, diff);


### PR DESCRIPTION
Unity does not handle special cases for divisions by zero, let’s say that’s our way of improving it while preserving legacy behavior!

This fixes the glitch soup in Shadowed Cove.