### PR TITLE
Settings slider speed

### DIFF
--- a/crates/renderide/src/diagnostics/hud/windows/renderer_config/controls.rs
+++ b/crates/renderide/src/diagnostics/hud/windows/renderer_config/controls.rs
@@ -3,7 +3,7 @@
 use imgui::{Drag, SliderFlags};
 
 const SLIDER_DRAG_STEPS: f32 = 200.0;
-const MIN_U32_SLIDER_SPEED: f32 = 1.0;
+const MIN_U32_SLIDER_SPEED: f32 = 0.001;
 const MIN_F32_SLIDER_SPEED: f32 = 0.001;
 
 /// Edits a `u32` setting through an ImGui drag widget with clamped integer output.

--- a/crates/renderide/src/diagnostics/hud/windows/renderer_config/post_processing.rs
+++ b/crates/renderide/src/diagnostics/hud/windows/renderer_config/post_processing.rs
@@ -62,12 +62,11 @@ fn post_processing_gtao(ui: &imgui::Ui, g: &mut RendererSettings, dirty: &mut bo
 fn gtao_quality_controls(ui: &imgui::Ui, gtao: &mut GtaoSettings, dirty: &mut bool) {
     ui.text("Quality");
     ui.indent();
-    if drag_u32_slider_setting(
-        ui,
+    if ui.slider(
         "Quality level",
-        &mut gtao.quality_level,
         0,
         GTAO_MAX_QUALITY_LEVEL,
+        &mut gtao.quality_level,
     ) {
         *dirty = true;
     }


### PR DESCRIPTION
The `speed` parameter is the amount of change per pixel of mouse movement.
We should allow the user to need to move the mouse by hundreds of pixels for a single
value change if the range is really small (like 0->4).