### PR TITLE
Use mimalloc as global allocator for the renderer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2325,6 +2325,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2462,6 +2471,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -3482,6 +3500,7 @@ dependencies = [
  "libc",
  "logger",
  "lru",
+ "mimalloc",
  "naga",
  "naga_oil",
  "notify",

--- a/crates/renderide/Cargo.toml
+++ b/crates/renderide/Cargo.toml
@@ -117,6 +117,7 @@ gstreamer = { version = "0.25", optional = true }
 gstreamer-app = { version = "0.25", optional = true }
 gstreamer-video = { version = "0.25", optional = true }
 directories = "6.0"
+mimalloc = "0.1.52"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 wgpu = { version = "29.0", features = ["vulkan-portability"] }

--- a/crates/renderide/src/main.rs
+++ b/crates/renderide/src/main.rs
@@ -1,5 +1,10 @@
 //! Renderer binary entry point.
 
+use mimalloc::MiMalloc;
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
+
 fn main() {
     match renderide::run() {
         Ok(exit) => std::process::exit(exit.process_code()),


### PR DESCRIPTION
This switches the renderer process from using the default system allocator to using [mimalloc](https://github.com/Gawdl3y/Renderide.git) as the global allocator.

In my not-super-scientific testing, this results in slightly improved performance (1-3ms CPU frametime in Black Mesa Train Ride) in exchange for only around 10% higher max memory usage for the renderer process, when compared to the Windows/MSVC system allocator. Given the renderer already doesn't use all that much memory, the tradeoff doesn't seem very significant. The performance gains may be even better on different OSes/compilers, and the memory usage penalty might be smaller or even actually better (less memory usage) than the system allocator.

Since the renderer already does a fairly good job of using pools/arenas, the vast majority of the performance gains likely come from improved locality resulting in better use of CPU cache, rather than raw allocation speed (which should also be improved).